### PR TITLE
Rename Go module/package org to poseidon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Notable changes between releases.
 
 ## Latest
 
+* Transfer Matchbox from coreos to poseidon GitHub Org
+* Publish container images at [quay.io/poseidon/matchbox](https://quay.io/repository/poseidon/matchbox)
 * Build Matchbox with Go v1.11.5 for images and binaries
 * Update container image base from alpine:3.6 to alpine:3.9
 * Render Container Linux Configs as Ignition v2.2.0

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ export GO111MODULE=on
 export GOFLAGS=-mod=vendor
 
 VERSION=$(shell git describe --tags --match=v* --always --dirty)
-LD_FLAGS="-w -X github.com/coreos/matchbox/matchbox/version.Version=$(VERSION)"
+LD_FLAGS="-w -X github.com/poseidon/matchbox/matchbox/version.Version=$(VERSION)"
 
-REPO=github.com/coreos/matchbox
-LOCAL_REPO=coreos/matchbox
-IMAGE_REPO=quay.io/coreos/matchbox
+REPO=github.com/poseidon/matchbox
+LOCAL_REPO=poseidon/matchbox
+IMAGE_REPO=quay.io/poseidon/matchbox
 
 .PHONY: all
 all: build test vet lint fmt

--- a/cmd/bootcmd/main.go
+++ b/cmd/bootcmd/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/coreos/matchbox/matchbox/cli"
+import "github.com/poseidon/matchbox/matchbox/cli"
 
 func main() {
 	cli.Execute()

--- a/cmd/matchbox/main.go
+++ b/cmd/matchbox/main.go
@@ -7,14 +7,14 @@ import (
 	"net/http"
 	"os"
 
-	web "github.com/coreos/matchbox/matchbox/http"
-	"github.com/coreos/matchbox/matchbox/rpc"
-	"github.com/coreos/matchbox/matchbox/server"
-	"github.com/coreos/matchbox/matchbox/sign"
-	"github.com/coreos/matchbox/matchbox/storage"
-	"github.com/coreos/matchbox/matchbox/tlsutil"
-	"github.com/coreos/matchbox/matchbox/version"
 	"github.com/coreos/pkg/flagutil"
+	web "github.com/poseidon/matchbox/matchbox/http"
+	"github.com/poseidon/matchbox/matchbox/rpc"
+	"github.com/poseidon/matchbox/matchbox/server"
+	"github.com/poseidon/matchbox/matchbox/sign"
+	"github.com/poseidon/matchbox/matchbox/storage"
+	"github.com/poseidon/matchbox/matchbox/tlsutil"
+	"github.com/poseidon/matchbox/matchbox/version"
 	"github.com/sirupsen/logrus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/coreos/matchbox
+module github.com/poseidon/matchbox
 
 require (
 	github.com/ajeddeloh/go-json v0.0.0-20160803184958-73d058cf8437 // indirect

--- a/matchbox/cli/generic_create.go
+++ b/matchbox/cli/generic_create.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // genericPutCmd creates and updates Generic templates.

--- a/matchbox/cli/group_create.go
+++ b/matchbox/cli/group_create.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 // groupPutCmd creates and updates Groups.

--- a/matchbox/cli/group_describe.go
+++ b/matchbox/cli/group_describe.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // groupDescribeCmd describes a Group.

--- a/matchbox/cli/group_list.go
+++ b/matchbox/cli/group_list.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // groupListCmd lists Groups.

--- a/matchbox/cli/ignition_create.go
+++ b/matchbox/cli/ignition_create.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // ignitionPutCmd creates and updates Ignition templates.

--- a/matchbox/cli/profile_create.go
+++ b/matchbox/cli/profile_create.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 // profilePutCmd creates and updates Profiles.

--- a/matchbox/cli/profile_describe.go
+++ b/matchbox/cli/profile_describe.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // profileDescribeCmd describes a Profile.

--- a/matchbox/cli/profile_list.go
+++ b/matchbox/cli/profile_list.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // profileListCmd lists Profiles.

--- a/matchbox/cli/root.go
+++ b/matchbox/cli/root.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/coreos/matchbox/matchbox/client"
-	"github.com/coreos/matchbox/matchbox/tlsutil"
+	"github.com/poseidon/matchbox/matchbox/client"
+	"github.com/poseidon/matchbox/matchbox/tlsutil"
 )
 
 var (

--- a/matchbox/client/client.go
+++ b/matchbox/client/client.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/coreos/matchbox/matchbox/rpc/rpcpb"
+	"github.com/poseidon/matchbox/matchbox/rpc/rpcpb"
 )
 
 var (

--- a/matchbox/http/cloud.go
+++ b/matchbox/http/cloud.go
@@ -9,8 +9,8 @@ import (
 	cloudinit "github.com/coreos/coreos-cloudinit/config"
 	"github.com/sirupsen/logrus"
 
-	"github.com/coreos/matchbox/matchbox/server"
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/server"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // CloudConfig defines a cloud-init config.
@@ -21,7 +21,7 @@ type CloudConfig struct {
 // cloudHandler returns a handler that responds with the cloud config matching
 // the request.
 // DEPRECATED: Please migrate to using Container Linux configs.
-// https://github.com/coreos/matchbox/blob/master/Documentation/cloud-config.md
+// https://github.com/poseidon/matchbox/blob/master/Documentation/cloud-config.md
 func (s *Server) cloudHandler(core server.Server) http.Handler {
 	fn := func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()

--- a/matchbox/http/cloud_test.go
+++ b/matchbox/http/cloud_test.go
@@ -9,9 +9,9 @@ import (
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/coreos/matchbox/matchbox/server"
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
-	fake "github.com/coreos/matchbox/matchbox/storage/testfakes"
+	"github.com/poseidon/matchbox/matchbox/server"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
+	fake "github.com/poseidon/matchbox/matchbox/storage/testfakes"
 )
 
 func TestCloudHandler(t *testing.T) {

--- a/matchbox/http/context.go
+++ b/matchbox/http/context.go
@@ -5,7 +5,7 @@ import (
 
 	"context"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 // unexported key prevents collisions

--- a/matchbox/http/context_test.go
+++ b/matchbox/http/context_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 func TestContextProfile(t *testing.T) {

--- a/matchbox/http/generic.go
+++ b/matchbox/http/generic.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/coreos/matchbox/matchbox/server"
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/server"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // genericHandler returns a handler that responds with the generic config

--- a/matchbox/http/generic_test.go
+++ b/matchbox/http/generic_test.go
@@ -9,9 +9,9 @@ import (
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/coreos/matchbox/matchbox/server"
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
-	fake "github.com/coreos/matchbox/matchbox/storage/testfakes"
+	"github.com/poseidon/matchbox/matchbox/server"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
+	fake "github.com/poseidon/matchbox/matchbox/storage/testfakes"
 )
 
 func TestGenericHandler(t *testing.T) {

--- a/matchbox/http/grub_test.go
+++ b/matchbox/http/grub_test.go
@@ -9,7 +9,7 @@ import (
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
-	fake "github.com/coreos/matchbox/matchbox/storage/testfakes"
+	fake "github.com/poseidon/matchbox/matchbox/storage/testfakes"
 )
 
 func TestGrubHandler(t *testing.T) {

--- a/matchbox/http/handlers.go
+++ b/matchbox/http/handlers.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/coreos/matchbox/matchbox/server"
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/server"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // homeHandler shows the server name for rooted requests. Otherwise, a 404 is

--- a/matchbox/http/handlers_test.go
+++ b/matchbox/http/handlers_test.go
@@ -9,9 +9,9 @@ import (
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/coreos/matchbox/matchbox/server"
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
-	fake "github.com/coreos/matchbox/matchbox/storage/testfakes"
+	"github.com/poseidon/matchbox/matchbox/server"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
+	fake "github.com/poseidon/matchbox/matchbox/storage/testfakes"
 )
 
 func TestSelectGroup(t *testing.T) {

--- a/matchbox/http/ignition.go
+++ b/matchbox/http/ignition.go
@@ -9,8 +9,8 @@ import (
 	ignition "github.com/coreos/ignition/config/v2_2"
 	"github.com/sirupsen/logrus"
 
-	"github.com/coreos/matchbox/matchbox/server"
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/server"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // ignitionHandler returns a handler that responds with the Ignition config

--- a/matchbox/http/ignition_test.go
+++ b/matchbox/http/ignition_test.go
@@ -9,9 +9,9 @@ import (
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/coreos/matchbox/matchbox/server"
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
-	fake "github.com/coreos/matchbox/matchbox/storage/testfakes"
+	"github.com/poseidon/matchbox/matchbox/server"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
+	fake "github.com/poseidon/matchbox/matchbox/storage/testfakes"
 )
 
 func TestIgnitionHandler_V2_1_JSON(t *testing.T) {

--- a/matchbox/http/ipxe_test.go
+++ b/matchbox/http/ipxe_test.go
@@ -9,8 +9,8 @@ import (
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
-	fake "github.com/coreos/matchbox/matchbox/storage/testfakes"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
+	fake "github.com/poseidon/matchbox/matchbox/storage/testfakes"
 )
 
 func TestIPXEInspect(t *testing.T) {

--- a/matchbox/http/metadata_test.go
+++ b/matchbox/http/metadata_test.go
@@ -11,7 +11,7 @@ import (
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 func TestMetadataHandler(t *testing.T) {

--- a/matchbox/http/parse.go
+++ b/matchbox/http/parse.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 // collectVariables collects group selectors, metadata, and request-scoped

--- a/matchbox/http/server.go
+++ b/matchbox/http/server.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/coreos/matchbox/matchbox/server"
-	"github.com/coreos/matchbox/matchbox/sign"
+	"github.com/poseidon/matchbox/matchbox/server"
+	"github.com/poseidon/matchbox/matchbox/sign"
 )
 
 // Config configures a Server.

--- a/matchbox/http/test_fixtures.go
+++ b/matchbox/http/test_fixtures.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 var (

--- a/matchbox/rpc/errors.go
+++ b/matchbox/rpc/errors.go
@@ -4,7 +4,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	"github.com/coreos/matchbox/matchbox/server"
+	"github.com/poseidon/matchbox/matchbox/server"
 )
 
 var (

--- a/matchbox/rpc/errors_test.go
+++ b/matchbox/rpc/errors_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 
-	"github.com/coreos/matchbox/matchbox/server"
+	"github.com/poseidon/matchbox/matchbox/server"
 )
 
 func TestGRPCError(t *testing.T) {

--- a/matchbox/rpc/generic.go
+++ b/matchbox/rpc/generic.go
@@ -3,9 +3,9 @@ package rpc
 import (
 	"golang.org/x/net/context"
 
-	"github.com/coreos/matchbox/matchbox/rpc/rpcpb"
-	"github.com/coreos/matchbox/matchbox/server"
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/rpc/rpcpb"
+	"github.com/poseidon/matchbox/matchbox/server"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // genericServer takes a matchbox Server and implements a gRPC GenericServer.

--- a/matchbox/rpc/groups.go
+++ b/matchbox/rpc/groups.go
@@ -3,9 +3,9 @@ package rpc
 import (
 	"golang.org/x/net/context"
 
-	"github.com/coreos/matchbox/matchbox/rpc/rpcpb"
-	"github.com/coreos/matchbox/matchbox/server"
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/rpc/rpcpb"
+	"github.com/poseidon/matchbox/matchbox/server"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // groupServer takes a matchbox Server and implements a gRPC GroupsServer.

--- a/matchbox/rpc/grpc.go
+++ b/matchbox/rpc/grpc.go
@@ -6,8 +6,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/coreos/matchbox/matchbox/rpc/rpcpb"
-	"github.com/coreos/matchbox/matchbox/server"
+	"github.com/poseidon/matchbox/matchbox/rpc/rpcpb"
+	"github.com/poseidon/matchbox/matchbox/server"
 )
 
 // NewServer wraps the matchbox Server to return a new gRPC Server.

--- a/matchbox/rpc/ignition.go
+++ b/matchbox/rpc/ignition.go
@@ -3,9 +3,9 @@ package rpc
 import (
 	"golang.org/x/net/context"
 
-	"github.com/coreos/matchbox/matchbox/rpc/rpcpb"
-	"github.com/coreos/matchbox/matchbox/server"
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/rpc/rpcpb"
+	"github.com/poseidon/matchbox/matchbox/server"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // ignitionServer takes a matchbox Server and implements a gRPC IgnitionServer.

--- a/matchbox/rpc/profiles.go
+++ b/matchbox/rpc/profiles.go
@@ -3,9 +3,9 @@ package rpc
 import (
 	"golang.org/x/net/context"
 
-	"github.com/coreos/matchbox/matchbox/rpc/rpcpb"
-	"github.com/coreos/matchbox/matchbox/server"
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/rpc/rpcpb"
+	"github.com/poseidon/matchbox/matchbox/server"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // profileServer takes a matchbox Server and implements a gRPC ProfilesServer.

--- a/matchbox/rpc/rpcpb/rpc.pb.go
+++ b/matchbox/rpc/rpcpb/rpc.pb.go
@@ -15,7 +15,7 @@ package rpcpb
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import serverpb "github.com/coreos/matchbox/matchbox/server/serverpb"
+import serverpb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 
 import (
 	context "golang.org/x/net/context"

--- a/matchbox/rpc/select.go
+++ b/matchbox/rpc/select.go
@@ -3,9 +3,9 @@ package rpc
 import (
 	"golang.org/x/net/context"
 
-	"github.com/coreos/matchbox/matchbox/rpc/rpcpb"
-	"github.com/coreos/matchbox/matchbox/server"
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/rpc/rpcpb"
+	"github.com/poseidon/matchbox/matchbox/server"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
 )
 
 // selectServer wraps a matchbox Server to be suitable for gRPC registration.

--- a/matchbox/server/server.go
+++ b/matchbox/server/server.go
@@ -6,9 +6,9 @@ import (
 
 	"context"
 
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
-	"github.com/coreos/matchbox/matchbox/storage"
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/storage"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 // Possible service errors

--- a/matchbox/server/server_test.go
+++ b/matchbox/server/server_test.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"github.com/stretchr/testify/assert"
 
-	pb "github.com/coreos/matchbox/matchbox/server/serverpb"
-	"github.com/coreos/matchbox/matchbox/storage"
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
-	fake "github.com/coreos/matchbox/matchbox/storage/testfakes"
+	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
+	"github.com/poseidon/matchbox/matchbox/storage"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
+	fake "github.com/poseidon/matchbox/matchbox/storage/testfakes"
 )
 
 func TestSelectGroup(t *testing.T) {

--- a/matchbox/server/serverpb/messages.pb.go
+++ b/matchbox/server/serverpb/messages.pb.go
@@ -47,7 +47,7 @@ package serverpb
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import storagepb "github.com/coreos/matchbox/matchbox/storage/storagepb"
+import storagepb "github.com/poseidon/matchbox/matchbox/storage/storagepb"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/matchbox/storage/filestore.go
+++ b/matchbox/storage/filestore.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 	"github.com/sirupsen/logrus"
 )
 

--- a/matchbox/storage/filestore_test.go
+++ b/matchbox/storage/filestore_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
-	fake "github.com/coreos/matchbox/matchbox/storage/testfakes"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
+	fake "github.com/poseidon/matchbox/matchbox/storage/testfakes"
 )
 
 func TestGroupCRUD(t *testing.T) {

--- a/matchbox/storage/storage.go
+++ b/matchbox/storage/storage.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"errors"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 // Storage errors

--- a/matchbox/storage/testfakes/broken_store.go
+++ b/matchbox/storage/testfakes/broken_store.go
@@ -3,7 +3,7 @@ package testfakes
 import (
 	"errors"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 var (

--- a/matchbox/storage/testfakes/empty_store.go
+++ b/matchbox/storage/testfakes/empty_store.go
@@ -3,7 +3,7 @@ package testfakes
 import (
 	"fmt"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 // EmptyStore is used for testing purposes.

--- a/matchbox/storage/testfakes/fixed_store.go
+++ b/matchbox/storage/testfakes/fixed_store.go
@@ -3,7 +3,7 @@ package testfakes
 import (
 	"fmt"
 
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 // FixedStore is used for testing purposes.

--- a/matchbox/storage/testfakes/fixtures.go
+++ b/matchbox/storage/testfakes/fixtures.go
@@ -1,7 +1,7 @@
 package testfakes
 
 import (
-	"github.com/coreos/matchbox/matchbox/storage/storagepb"
+	"github.com/poseidon/matchbox/matchbox/storage/storagepb"
 )
 
 var (


### PR DESCRIPTION
* Matchbox has moved to a new home in Poseidon
* Update Makefile so container image name uses poseidon instead of coreos
* Publish container images to quay.io/poseidon/matchbox