### PR TITLE
Update links to Matchbox, Quay, and terraform provider plugins

### DIFF
--- a/Documentation/config.md
+++ b/Documentation/config.md
@@ -35,8 +35,8 @@ Configuration arguments can be provided as flags or as environment variables.
 
 ```sh
 $ ./bin/matchbox -version
-$ sudo rkt run quay.io/coreos/matchbox:latest -- -version
-$ sudo docker run quay.io/coreos/matchbox:latest -version
+$ sudo rkt run quay.io/poseidon/matchbox:latest -- -version
+$ sudo docker run quay.io/poseidon/matchbox:latest -version
 ```
 
 ## Usage
@@ -50,13 +50,13 @@ $ ./bin/matchbox -address=0.0.0.0:8080 -log-level=debug -data-path=examples -ass
 Run the latest ACI with rkt.
 
 ```sh
-$ sudo rkt run --mount volume=assets,target=/var/lib/matchbox/assets --volume assets,kind=host,source=$PWD/examples/assets quay.io/coreos/matchbox:latest -- -address=0.0.0.0:8080 -log-level=debug
+$ sudo rkt run --mount volume=assets,target=/var/lib/matchbox/assets --volume assets,kind=host,source=$PWD/examples/assets quay.io/poseidon/matchbox:latest -- -address=0.0.0.0:8080 -log-level=debug
 ```
 
 Run the latest Docker image.
 
 ```sh
-$ sudo docker run -p 8080:8080 --rm -v $PWD/examples/assets:/var/lib/matchbox/assets:Z quay.io/coreos/matchbox:latest -address=0.0.0.0:8080 -log-level=debug
+$ sudo docker run -p 8080:8080 --rm -v $PWD/examples/assets:/var/lib/matchbox/assets:Z quay.io/poseidon/matchbox:latest -address=0.0.0.0:8080 -log-level=debug
 ```
 
 ### With examples
@@ -64,13 +64,13 @@ $ sudo docker run -p 8080:8080 --rm -v $PWD/examples/assets:/var/lib/matchbox/as
 Mount `examples` to pre-load the [example](../examples/README.md) machine groups and profiles. Run the container with rkt,
 
 ```sh
-$ sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/matchbox/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/matchbox:latest -- -address=0.0.0.0:8080 -log-level=debug
+$ sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/matchbox/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/poseidon/matchbox:latest -- -address=0.0.0.0:8080 -log-level=debug
 ```
 
 or with Docker.
 
 ```sh
-$ sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z quay.io/coreos/matchbox:latest -address=0.0.0.0:8080 -log-level=debug
+$ sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z quay.io/poseidon/matchbox:latest -address=0.0.0.0:8080 -log-level=debug
 ```
 
 ### With gRPC API
@@ -94,7 +94,7 @@ $ ./bin/bootcmd profile list --endpoints 127.0.0.1:8081 --ca-file examples/etc/m
 Run the ACI with rkt and TLS credentials from `examples/etc/matchbox`.
 
 ```sh
-$ sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=$PWD/examples,readOnly=true --mount volume=config,target=/etc/matchbox --volume config,kind=host,source=$PWD/examples/etc/matchbox --mount volume=groups,target=/var/lib/matchbox/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/matchbox:latest -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+$ sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=$PWD/examples,readOnly=true --mount volume=config,target=/etc/matchbox --volume config,kind=host,source=$PWD/examples/etc/matchbox --mount volume=groups,target=/var/lib/matchbox/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/poseidon/matchbox:latest -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 ```
 
 A `bootcmd` client can call the gRPC API running at the IP used in the rkt example.
@@ -108,7 +108,7 @@ $ ./bin/bootcmd profile list --endpoints 172.18.0.2:8081 --ca-file examples/etc/
 Run the Docker image with TLS credentials from `examples/etc/matchbox`.
 
 ```sh
-$ sudo docker run -p 8080:8080 -p 8081:8081 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/etc/matchbox:/etc/matchbox:Z,ro -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z quay.io/coreos/matchbox:latest -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+$ sudo docker run -p 8080:8080 -p 8081:8081 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/etc/matchbox:/etc/matchbox:Z,ro -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z quay.io/poseidon/matchbox:latest -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 ```
 
 A `bootcmd` client can call the gRPC API running at the IP used in the Docker example.
@@ -129,11 +129,11 @@ $ ./bin/matchbox -address=0.0.0.0:8080 -key-ring-path matchbox/sign/fixtures/sec
 Run the ACI with a test key.
 
 ```sh
-$ sudo rkt run --net=metal0:IP=172.18.0.2 --set-env=MATCHBOX_PASSPHRASE=test --mount volume=secrets,target=/secrets --volume secrets,kind=host,source=$PWD/matchbox/sign/fixtures --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/matchbox/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/coreos/matchbox:latest -- -address=0.0.0.0:8080 -key-ring-path secrets/secring.gpg
+$ sudo rkt run --net=metal0:IP=172.18.0.2 --set-env=MATCHBOX_PASSPHRASE=test --mount volume=secrets,target=/secrets --volume secrets,kind=host,source=$PWD/matchbox/sign/fixtures --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/matchbox/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/poseidon/matchbox:latest -- -address=0.0.0.0:8080 -key-ring-path secrets/secring.gpg
 ```
 
 Run the Docker image with a test key.
 
 ```sh
-$ sudo docker run -p 8080:8080 --rm --env MATCHBOX_PASSPHRASE=test -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z -v $PWD/matchbox/sign/fixtures:/secrets:Z quay.io/coreos/matchbox:latest -address=0.0.0.0:8080 -log-level=debug -key-ring-path secrets/secring.gpg
+$ sudo docker run -p 8080:8080 --rm --env MATCHBOX_PASSPHRASE=test -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z -v $PWD/matchbox/sign/fixtures:/secrets:Z quay.io/poseidon/matchbox:latest -address=0.0.0.0:8080 -log-level=debug -key-ring-path secrets/secring.gpg
 ```

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -17,11 +17,11 @@ Choose one of the supported installation options:
 
 ## Download
 
-Download the latest matchbox [release](https://github.com/coreos/matchbox/releases) to the provisioner host.
+Download the latest matchbox [release](https://github.com/poseidon/matchbox/releases) to the provisioner host.
 
 ```sh
-$ wget https://github.com/coreos/matchbox/releases/download/v0.7.1/matchbox-v0.7.1-linux-amd64.tar.gz
-$ wget https://github.com/coreos/matchbox/releases/download/v0.7.1/matchbox-v0.7.1-linux-amd64.tar.gz.asc
+$ wget https://github.com/poseidon/matchbox/releases/download/v0.7.1/matchbox-v0.7.1-linux-amd64.tar.gz
+$ wget https://github.com/poseidon/matchbox/releases/download/v0.7.1/matchbox-v0.7.1-linux-amd64.tar.gz.asc
 ```
 
 Verify the release has been signed by the [CoreOS App Signing Key](https://coreos.com/security/app-signing-key/).
@@ -252,23 +252,23 @@ For large production environments, use a cache proxy or mirror suitable for your
 
 ## Network
 
-Review [network setup](https://github.com/coreos/matchbox/blob/master/Documentation/network-setup.md) with your network administrator to set up DHCP, TFTP, and DNS services on your network. At a high level, your goals are to:
+Review [network setup](https://github.com/poseidon/matchbox/blob/master/Documentation/network-setup.md) with your network administrator to set up DHCP, TFTP, and DNS services on your network. At a high level, your goals are to:
 
 * Chainload PXE firmwares to iPXE
 * Point iPXE client machines to the `matchbox` iPXE HTTP endpoint `http://matchbox.example.com:8080/boot.ipxe`
 * Ensure `matchbox.example.com` resolves to your `matchbox` deployment
 
-CoreOS provides [dnsmasq](https://github.com/coreos/matchbox/tree/master/contrib/dnsmasq) as `quay.io/coreos/dnsmasq`, if you wish to use rkt or Docker.
+CoreOS provides [dnsmasq](https://github.com/poseidon/matchbox/tree/master/contrib/dnsmasq) as `quay.io/coreos/dnsmasq`, if you wish to use rkt or Docker.
 
 ## rkt
 
 Run the container image with rkt.
 
-latest or most recent tagged `matchbox` [release](https://github.com/coreos/matchbox/releases) ACI. Trust the [CoreOS App Signing Key](https://coreos.com/security/app-signing-key/) for image signature verification.
+latest or most recent tagged `matchbox` [release](https://github.com/poseidon/matchbox/releases) ACI. Trust the [CoreOS App Signing Key](https://coreos.com/security/app-signing-key/) for image signature verification.
 
 ```sh
 $ mkdir -p /var/lib/matchbox/assets
-$ sudo rkt run --net=host --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=/var/lib/matchbox quay.io/coreos/matchbox:latest --mount volume=config,target=/etc/matchbox --volume config,kind=host,source=/etc/matchbox,readOnly=true -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+$ sudo rkt run --net=host --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=/var/lib/matchbox quay.io/poseidon/matchbox:latest --mount volume=config,target=/etc/matchbox --volume config,kind=host,source=/etc/matchbox,readOnly=true -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 ```
 
 Create machine profiles, groups, or Ignition configs by adding files to `/var/lib/matchbox`.
@@ -279,7 +279,7 @@ Run the container image with docker.
 
 ```sh
 $ mkdir -p /var/lib/matchbox/assets
-$ sudo docker run --net=host --rm -v /var/lib/matchbox:/var/lib/matchbox:Z -v /etc/matchbox:/etc/matchbox:Z,ro quay.io/coreos/matchbox:latest -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+$ sudo docker run --net=host --rm -v /var/lib/matchbox:/var/lib/matchbox:Z -v /etc/matchbox:/etc/matchbox:Z,ro quay.io/poseidon/matchbox:latest -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 ```
 
 Create machine profiles, groups, or Ignition configs by adding files to `/var/lib/matchbox`.

--- a/Documentation/dev/release.md
+++ b/Documentation/dev/release.md
@@ -26,8 +26,8 @@ $ git push origin master
 Travis CI will build the Docker image and push it to Quay.io when the tag is pushed to master. Verify the new image and version.
 
 ```sh
-$ sudo docker run quay.io/coreos/matchbox:$VERSION -version
-$ sudo rkt run --no-store quay.io/coreos/matchbox:$VERSION -- -version
+$ sudo docker run quay.io/poseidon/matchbox:$VERSION -version
+$ sudo rkt run --no-store quay.io/poseidon/matchbox:$VERSION -- -version
 ```
 
 ## Github release

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -18,10 +18,10 @@ $ # check Docker's docs to install Docker 1.8+ on Debian/Ubuntu
 $ sudo apt-get install virt-manager virtinst qemu-kvm
 ```
 
-Clone the [matchbox](https://github.com/coreos/matchbox) source which contains the examples and scripts.
+Clone the [matchbox](https://github.com/poseidon/matchbox) source which contains the examples and scripts.
 
 ```sh
-$ git clone https://github.com/coreos/matchbox.git
+$ git clone https://github.com/poseidon/matchbox.git
 $ cd matchbox
 ```
 
@@ -68,7 +68,7 @@ Take a look at the [etcd3 groups](../examples/groups/etcd3) to get an idea of ho
 If you prefer to start the containers yourself, instead of using `devnet`,
 
 ```sh
-$ sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd3:/var/lib/matchbox/groups:Z quay.io/coreos/matchbox:latest -address=0.0.0.0:8080 -log-level=debug
+$ sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd3:/var/lib/matchbox/groups:Z quay.io/poseidon/matchbox:latest -address=0.0.0.0:8080 -log-level=debug
 $ sudo docker run --name dnsmasq --cap-add=NET_ADMIN -v $PWD/contrib/dnsmasq/docker0.conf:/etc/dnsmasq.conf:Z quay.io/coreos/dnsmasq -d
 ```
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -30,26 +30,24 @@ $ openssl s_client -connect matchbox.example.com:8081 \
 
 ## Terraform
 
-Install [Terraform][terraform-dl] v0.9+ on your system.
+Install [Terraform][terraform-dl] v0.11+ on your system.
 
 ```sh
 $ terraform version
-Terraform v0.9.4
+Terraform v0.11.13
 ```
 
-Add the `terraform-provider-matchbox` plugin binary on your system.
+Add the [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-$ wget https://github.com/coreos/terraform-provider-matchbox/releases/download/v0.1.0/terraform-provider-matchbox-v0.1.0-linux-amd64.tar.gz
-$ tar xzf terraform-provider-matchbox-v0.1.0-linux-amd64.tar.gz
+wget https://github.com/poseidon/terraform-provider-matchbox/releases/download/v0.2.3/terraform-provider-matchbox-v0.2.3-linux-amd64.tar.gz
+tar xzf terraform-provider-matchbox-v0.2.3-linux-amd64.tar.gz
+mv terraform-provider-matchbox-v0.2.3-linux-amd64/terraform-provider-matchbox ~/.terraform.d/plugins/terraform-provider-matchbox_v0.2.3
 ```
 
-Add the plugin to your `~/.terraformrc`.
-
-```hcl
-providers {
-  matchbox = "/path/to/terraform-provider-matchbox"
-}
+```sh
+$ wget https://github.com/poseidon/terraform-provider-matchbox/releases/download/v0.2.3/terraform-provider-matchbox-v0.2.3-linux-amd64.tar.gz
+$ tar xzf terraform-provider-matchbox-v0.2.3-linux-amd64.tar.gz
 ```
 
 ## First cluster
@@ -57,7 +55,7 @@ providers {
 Clone the matchbox source and take a look at the Terraform examples.
 
 ```sh
-$ git clone https://github.com/coreos/matchbox.git
+$ git clone https://github.com/poseidon/matchbox.git
 $ cd matchbox/examples/terraform
 ```
 
@@ -169,7 +167,7 @@ Read [network-setup.md](network-setup.md) for the complete range of options. Net
 * May configure subnets, architectures, or specific machines to delegate to matchbox
 * May place matchbox behind a menu entry (timeout and default to matchbox)
 
-If you've never setup a PXE-enabled network before or you're trying to setup a home lab, checkout the [quay.io/coreos/dnsmasq](https://quay.io/repository/coreos/dnsmasq) container image [copy-paste examples](https://github.com/coreos/matchbox/blob/master/Documentation/network-setup.md#coreosdnsmasq) and see the section about [proxy-DHCP](https://github.com/coreos/matchbox/blob/master/Documentation/network-setup.md#proxy-dhcp).
+If you've never setup a PXE-enabled network before or you're trying to setup a home lab, checkout the [quay.io/coreos/dnsmasq](https://quay.io/repository/coreos/dnsmasq) container image [copy-paste examples](https://github.com/poseidon/matchbox/blob/master/Documentation/network-setup.md#coreosdnsmasq) and see the section about [proxy-DHCP](https://github.com/poseidon/matchbox/blob/master/Documentation/network-setup.md#proxy-dhcp).
 
 ## Boot
 

--- a/Documentation/matchbox.md
+++ b/Documentation/matchbox.md
@@ -19,7 +19,7 @@ See [configuration](config.md) flags and variables.
 ## API
 
 * [HTTP API](api.md)
-* [gRPC API](https://godoc.org/github.com/coreos/matchbox/matchbox/client)
+* [gRPC API](https://godoc.org/github.com/poseidon/matchbox/matchbox/client)
 
 ## Data
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# matchbox [![Build Status](https://travis-ci.org/coreos/matchbox.svg?branch=master)](https://travis-ci.org/coreos/matchbox) [![GoDoc](https://godoc.org/github.com/coreos/matchbox?status.svg)](https://godoc.org/github.com/coreos/matchbox) [![Docker Repository on Quay](https://quay.io/repository/coreos/matchbox/status "Docker Repository on Quay")](https://quay.io/repository/coreos/matchbox) [![IRC](https://img.shields.io/badge/irc-%23coreos-449FD8.svg)](https://botbot.me/freenode/coreos)
+# matchbox [![Build Status](https://travis-ci.org/coreos/matchbox.svg?branch=master)](https://travis-ci.org/coreos/matchbox) [![GoDoc](https://godoc.org/github.com/poseidon/matchbox?status.svg)](https://godoc.org/github.com/poseidon/matchbox) [![Docker Repository on Quay](https://quay.io/repository/coreos/matchbox/status "Docker Repository on Quay")](https://quay.io/repository/coreos/matchbox) [![IRC](https://img.shields.io/badge/irc-%23coreos-449FD8.svg)](https://botbot.me/freenode/coreos)
 
 `matchbox` is a service that matches bare-metal machines (based on labels like MAC, UUID, etc.) to profiles that PXE boot and provision Container Linux clusters. Profiles specify the kernel/initrd, kernel arguments, iPXE config, GRUB config, [Container Linux Config][cl-config], or other configs a machine should use. Matchbox can be [installed](Documentation/deployment.md) as a binary, RPM, container image, or deployed on a Kubernetes cluster and it provides an authenticated gRPC API for clients like [Terraform][terraform].
 
@@ -10,7 +10,7 @@
   * [Container Linux Config][cl-config]
   * [Cloud-Config][cloud-config]
 * [Configuration](Documentation/config.md)
-* [HTTP API](Documentation/api.md) / [gRPC API](https://godoc.org/github.com/coreos/matchbox/matchbox/client)
+* [HTTP API](Documentation/api.md) / [gRPC API](https://godoc.org/github.com/poseidon/matchbox/matchbox/client)
 * [Background: Machine Lifecycle](Documentation/machine-lifecycle.md)
 * [Background: PXE Booting](Documentation/network-booting.md)
 
@@ -42,9 +42,9 @@
 ## Contrib
 
 * [dnsmasq](contrib/dnsmasq/README.md) - Run DHCP, TFTP, and DNS services with docker or rkt
-* [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) - Terraform provider plugin for Matchbox
+* [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox) - Terraform provider plugin for Matchbox
 
 [docs]: https://coreos.com/matchbox/docs/latest
-[terraform]: https://github.com/coreos/terraform-provider-matchbox
+[terraform]: https://github.com/poseidon/terraform-provider-matchbox
 [cl-config]: Documentation/container-linux-config.md
 [cloud-config]: Documentation/cloud-config.md

--- a/contrib/k8s/matchbox-deployment.yaml
+++ b/contrib/k8s/matchbox-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: matchbox
-          image: quay.io/coreos/matchbox:v0.7.1
+          image: quay.io/poseidon/matchbox:v0.7.1
           env:
             - name: MATCHBOX_ADDRESS
               value: "0.0.0.0:8080"

--- a/contrib/systemd/matchbox-for-tectonic.service
+++ b/contrib/systemd/matchbox-for-tectonic.service
@@ -3,7 +3,7 @@ Description=CoreOS matchbox Server
 Documentation=https://github.com/coreos/matchbox
 
 [Service]
-Environment="IMAGE=quay.io/coreos/matchbox"
+Environment="IMAGE=quay.io/poseidon/matchbox"
 Environment="VERSION=v0.7.1"
 Environment="MATCHBOX_ADDRESS=0.0.0.0:8080"
 Environment="MATCHBOX_RPC_ADDRESS=0.0.0.0:8081"

--- a/contrib/systemd/matchbox-on-coreos.service
+++ b/contrib/systemd/matchbox-on-coreos.service
@@ -3,7 +3,7 @@ Description=CoreOS matchbox Server
 Documentation=https://github.com/coreos/matchbox
 
 [Service]
-Environment="IMAGE=quay.io/coreos/matchbox"
+Environment="IMAGE=quay.io/poseidon/matchbox"
 Environment="VERSION=v0.7.1"
 Environment="MATCHBOX_ADDRESS=0.0.0.0:8080"
 ExecStartPre=/usr/bin/mkdir -p /etc/matchbox

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -9,7 +9,7 @@ Follow the getting started [tutorial](../../../Documentation/getting-started.md)
 * Matchbox v0.6+ [installation](../../../Documentation/deployment.md) with gRPC API enabled
 * Matchbox provider credentials `client.crt`, `client.key`, and `ca.crt`
 * PXE [network boot](../../../Documentation/network-setup.md) environment
-* Terraform v0.11.x, [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox), and [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) installed locally
+* Terraform v0.11.x, [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox), and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
 * Machines with known DNS names and MAC addresses
 
 If you prefer to provision QEMU/KVM VMs on your local Linux machine, set up the matchbox [development environment](../../../Documentation/getting-started-docker.md).
@@ -27,28 +27,28 @@ $ terraform version
 Terraform v0.11.7
 ```
 
-Add the [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
+Add the [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/coreos/terraform-provider-matchbox/releases/download/v0.2.2/terraform-provider-matchbox-v0.2.2-linux-amd64.tar.gz
-tar xzf terraform-provider-matchbox-v0.2.2-linux-amd64.tar.gz
-mv terraform-provider-matchbox-v0.2.2-linux-amd64/terraform-provider-matchbox ~/.terraform.d/plugins/terraform-provider-matchbox_v0.2.2
+wget https://github.com/poseidon/terraform-provider-matchbox/releases/download/v0.2.3/terraform-provider-matchbox-v0.2.3-linux-amd64.tar.gz
+tar xzf terraform-provider-matchbox-v0.2.3-linux-amd64.tar.gz
+mv terraform-provider-matchbox-v0.2.3-linux-amd64/terraform-provider-matchbox ~/.terraform.d/plugins/terraform-provider-matchbox_v0.2.3
 ```
 
-Add the [terraform-provider-ct](https://github.com/coreos/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
+Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/coreos/terraform-provider-ct/releases/download/v0.3.0/terraform-provider-ct-v0.3.0-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.0-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.0
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
 ```
 
 ## Usage
 
-Clone the [matchbox](https://github.com/coreos/matchbox) project and take a look at the cluster examples.
+Clone the [matchbox](https://github.com/poseidon/matchbox) project and take a look at the cluster examples.
 
 ```sh
-$ git clone https://github.com/coreos/matchbox.git
+$ git clone https://github.com/poseidon/matchbox.git
 $ cd matchbox/examples/terraform/bootkube-install
 ```
 
@@ -71,7 +71,7 @@ provider "ct" {
 
 Copy the `terraform.tfvars.example` file to `terraform.tfvars`. It defines a few variables needed for examples. Set your `ssh_authorized_key` to use in the cluster definition.
 
-Note: With `cached_install="true"`, machines will PXE boot and install Container Linux from matchbox [assets](https://github.com/coreos/matchbox/blob/master/Documentation/api.md#assets). For convenience, `scripts/get-coreos` can download needed images.
+Note: With `cached_install="true"`, machines will PXE boot and install Container Linux from matchbox [assets](https://github.com/poseidon/matchbox/blob/master/Documentation/api.md#assets). For convenience, `scripts/get-coreos` can download needed images.
 
 ## Terraform
 

--- a/examples/terraform/etcd3-install/README.md
+++ b/examples/terraform/etcd3-install/README.md
@@ -9,7 +9,7 @@ Follow the getting started [tutorial](../../../Documentation/getting-started.md)
 * Matchbox v0.6+ [installation](../../../Documentation/deployment.md) with gRPC API enabled
 * Matchbox provider credentials `client.crt`, `client.key`, and `ca.crt`
 * PXE [network boot](../../../Documentation/network-setup.md) environment
-* Terraform v0.9+ and [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) installed locally on your system
+* Terraform v0.9+ and [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox) installed locally on your system
 * 3 machines with known DNS names and MAC addresses
 
 If you prefer to provision QEMU/KVM VMs on your local Linux machine, set up the matchbox [development environment](../../../Documentation/getting-started-docker.md).
@@ -20,10 +20,10 @@ sudo ./scripts/devnet create
 
 ## Usage
 
-Clone the [matchbox](https://github.com/coreos/matchbox) project and take a look at the cluster examples.
+Clone the [matchbox](https://github.com/poseidon/matchbox) project and take a look at the cluster examples.
 
 ```sh
-$ git clone https://github.com/coreos/matchbox.git
+$ git clone https://github.com/poseidon/matchbox.git
 $ cd matchbox/examples/terraform/etcd3-install
 ```
 
@@ -37,7 +37,7 @@ ssh_authorized_key = "ADD ME"
 
 Configs in `etcd3-install` configure the matchbox provider, define profiles (e.g. `cached-container-linux-install`, `etcd3`), and define 3 groups which match machines by MAC address to a profile. These resources declare that the machines should PXE boot, install Container Linux to disk, and provision themselves into peers in a 3-node etcd3 cluster.
 
-Note: The `cached-container-linux-install` profile will PXE boot and install Container Linux from matchbox [assets](https://github.com/coreos/matchbox/blob/master/Documentation/api.md#assets). If you have not populated the assets cache, use the `container-linux-install` profile to use public images (slower).
+Note: The `cached-container-linux-install` profile will PXE boot and install Container Linux from matchbox [assets](https://github.com/poseidon/matchbox/blob/master/Documentation/api.md#assets). If you have not populated the assets cache, use the `container-linux-install` profile to use public images (slower).
 
 ### Optional
 

--- a/examples/terraform/modules/README.md
+++ b/examples/terraform/modules/README.md
@@ -4,7 +4,7 @@ Matchbox provides Terraform [modules](https://www.terraform.io/docs/modules/usag
 
 ```hcl
 module "profiles" {
-  source = "git::https://github.com/coreos/matchbox.git//examples/terraform/modules/profiles?ref=08f4e9908b167fba608e60169ec6a803df9db37f"
+  source = "git::https://github.com/poseidon/matchbox.git//examples/terraform/modules/profiles?ref=08f4e9908b167fba608e60169ec6a803df9db37f"
   matchbox_http_endpoint = "${var.matchbox_http_endpoint}"
   container_linux_version = "${var.container_linux_version}"
   container_linux_channel = "${var.container_linux_channel}"

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -117,7 +117,7 @@ function rkt_create {
     --volume config,kind=host,source=$CONFIG_DIR,readOnly=true \
     --mount volume=data,target=/var/lib/matchbox \
     $DATA_MOUNT \
-    quay.io/coreos/matchbox:v0.7.1 -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
+    quay.io/poseidon/matchbox:v0.7.1 -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
 
   echo "Starting dnsmasq to provide DHCP/TFTP/DNS services"
   rkt rm --uuid-file=/var/run/dnsmasq-pod.uuid > /dev/null 2>&1
@@ -164,7 +164,7 @@ function docker_create {
     DATA_MOUNT=""
   else
     # Mount the given EXAMPLE
-    DATA_MOUNT="-v $PWD/examples:/var/lib/matchbox -v $DIR/../examples/groups/$EXAMPLE:/var/lib/matchbox/groups"
+    DATA_MOUNT="-v $PWD/examples:/var/lib/matchbox:Z -v $DIR/../examples/groups/$EXAMPLE:/var/lib/matchbox/groups:Z"
   fi
   
   docker run --name matchbox \
@@ -174,7 +174,7 @@ function docker_create {
     -v $CONFIG_DIR:/etc/matchbox:Z \
     -v $ASSETS_DIR:/var/lib/matchbox/assets:Z \
     $DATA_MOUNT \
-    quay.io/coreos/matchbox:v0.7.1 -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
+    quay.io/poseidon/matchbox:latest -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
 
   echo "Starting dnsmasq to provide DHCP/TFTP/DNS services"
   docker run --name dnsmasq \


### PR DESCRIPTION
* Bump versions of terraform provider plugins to current
* Verify getting started with docker and etcd example