### PR TITLE
Build binaries with Go v1.11.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 go:
   - "1.10.x"
   - "1.11.x"
-  - "1.11.5"
+  - "1.11.7"
   - "1.12.x"
 install:
   - go get golang.org/x/lint/golint
@@ -17,6 +17,6 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
-    go: '1.11.5'
+    go: '1.11.7'
 notifications:
   email: change

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Notable changes between releases.
 
 * Transfer Matchbox from coreos to poseidon GitHub Org
 * Publish container images at [quay.io/poseidon/matchbox](https://quay.io/repository/poseidon/matchbox)
-* Build Matchbox with Go v1.11.5 for images and binaries
+* Build Matchbox with Go v1.11.7 for images and binaries
 * Update container image base from alpine:3.6 to alpine:3.9
 * Render Container Linux Configs as Ignition v2.2.0
 * Validate raw Ignition configs with the v2.2 spec (warn-only)


### PR DESCRIPTION
* Document that release binaries and the container image binary will be built with Go v1.11.7