### PR TITLE
Prepare for Matchbox v0.8.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,10 @@ Notable changes between releases.
 
 ## Latest
 
-* Transfer Matchbox from coreos to poseidon GitHub Org
+
+## v0.8.0
+
+* Transfer Matchbox repo from coreos to poseidon GitHub Org
 * Publish container images at [quay.io/poseidon/matchbox](https://quay.io/repository/poseidon/matchbox)
 * Build Matchbox with Go v1.11.7 for images and binaries
 * Update container image base from alpine:3.6 to alpine:3.9

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -20,23 +20,23 @@ Choose one of the supported installation options:
 Download the latest matchbox [release](https://github.com/poseidon/matchbox/releases) to the provisioner host.
 
 ```sh
-$ wget https://github.com/poseidon/matchbox/releases/download/v0.7.1/matchbox-v0.7.1-linux-amd64.tar.gz
-$ wget https://github.com/poseidon/matchbox/releases/download/v0.7.1/matchbox-v0.7.1-linux-amd64.tar.gz.asc
+$ wget https://github.com/poseidon/matchbox/releases/download/v0.8.0/matchbox-v0.8.0-linux-amd64.tar.gz
+$ wget https://github.com/poseidon/matchbox/releases/download/v0.8.0/matchbox-v0.8.0-linux-amd64.tar.gz.asc
 ```
 
 Verify the release has been signed by Dalton Hubble's [GPG Key 8F515AD1602065C8](https://keyserver.ubuntu.com/pks/lookup?search=0x8F515AD1602065C8&op=vindex).
 
 ```sh
 $ gpg --keyserver keyserver.ubuntu.com --recv-key 8F515AD1602065C8
-$ gpg --verify matchbox-v0.7.1-linux-amd64.tar.gz.asc matchbox-v0.7.1-linux-amd64.tar.gz
+$ gpg --verify matchbox-v0.8.0-linux-amd64.tar.gz.asc matchbox-v0.8.0-linux-amd64.tar.gz
 gpg: Good signature from "Dalton Hubble <dghubble@gmail.com>"
 ```
 
 Untar the release.
 
 ```sh
-$ tar xzvf matchbox-v0.7.1-linux-amd64.tar.gz
-$ cd matchbox-v0.7.1-linux-amd64
+$ tar xzvf matchbox-v0.8.0-linux-amd64.tar.gz
+$ cd matchbox-v0.8.0-linux-amd64
 ```
 
 ## Install

--- a/Documentation/dev/release.md
+++ b/Documentation/dev/release.md
@@ -8,7 +8,7 @@ This guide covers releasing new versions of matchbox.
 Create a release commit which updates old version references.
 
 ```sh
-$ export VERSION=v0.7.1
+$ export VERSION=v0.8.0
 ```
 
 ## Tag
@@ -45,7 +45,7 @@ $ make release
 Verify the reported version.
 
 ```
-./_output/matchbox-v0.7.1-linux-amd64/matchbox -version
+./_output/matchbox-v0.8.0-linux-amd64/matchbox -version
 ```
 
 ## Signing

--- a/contrib/k8s/matchbox-deployment.yaml
+++ b/contrib/k8s/matchbox-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: matchbox
-          image: quay.io/poseidon/matchbox:v0.7.1
+          image: quay.io/poseidon/matchbox:v0.8.0
           env:
             - name: MATCHBOX_ADDRESS
               value: "0.0.0.0:8080"

--- a/contrib/systemd/matchbox-for-tectonic.service
+++ b/contrib/systemd/matchbox-for-tectonic.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/coreos/matchbox
 
 [Service]
 Environment="IMAGE=quay.io/poseidon/matchbox"
-Environment="VERSION=v0.7.1"
+Environment="VERSION=v0.8.0"
 Environment="MATCHBOX_ADDRESS=0.0.0.0:8080"
 Environment="MATCHBOX_RPC_ADDRESS=0.0.0.0:8081"
 Environment="MATCHBOX_LOG_LEVEL=debug"

--- a/contrib/systemd/matchbox-on-coreos.service
+++ b/contrib/systemd/matchbox-on-coreos.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/coreos/matchbox
 
 [Service]
 Environment="IMAGE=quay.io/poseidon/matchbox"
-Environment="VERSION=v0.7.1"
+Environment="VERSION=v0.8.0"
 Environment="MATCHBOX_ADDRESS=0.0.0.0:8080"
 ExecStartPre=/usr/bin/mkdir -p /etc/matchbox
 ExecStartPre=/usr/bin/mkdir -p /var/lib/matchbox/assets

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -117,7 +117,7 @@ function rkt_create {
     --volume config,kind=host,source=$CONFIG_DIR,readOnly=true \
     --mount volume=data,target=/var/lib/matchbox \
     $DATA_MOUNT \
-    quay.io/poseidon/matchbox:v0.7.1 -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
+    quay.io/poseidon/matchbox:v0.8.0 -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
 
   echo "Starting dnsmasq to provide DHCP/TFTP/DNS services"
   rkt rm --uuid-file=/var/run/dnsmasq-pod.uuid > /dev/null 2>&1


### PR DESCRIPTION
* Release Matchbox v0.8.0 before bumping big dependencies or components in future
* Establish the new Matchbox release process now that its managed under poseidon