### PR TITLE
Stop referencing outdated coreos/dnsmasq image

### DIFF
--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -7,7 +7,7 @@ The Kubernetes example provisions a 3 node Kubernetes v1.8.5 cluster. [bootkube]
 Ensure that you've gone through the [matchbox with docker](getting-started-docker.md) guide and understand the basics. In particular, you should be able to:
 
 * Use Docker to start `matchbox`
-* Create a network boot environment with `coreos/dnsmasq`
+* Create a network boot environment with `poseidon/dnsmasq`
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com`
 

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -252,7 +252,7 @@ Review [network setup](https://github.com/poseidon/matchbox/blob/master/Document
 * Point iPXE client machines to the `matchbox` iPXE HTTP endpoint `http://matchbox.example.com:8080/boot.ipxe`
 * Ensure `matchbox.example.com` resolves to your `matchbox` deployment
 
-CoreOS provides [dnsmasq](https://github.com/poseidon/matchbox/tree/master/contrib/dnsmasq) as `quay.io/coreos/dnsmasq`, if you wish to use rkt or Docker.
+Poseidon provides [dnsmasq](https://github.com/poseidon/matchbox/tree/master/contrib/dnsmasq) as `quay.io/poseidon/dnsmasq`, if you wish to use rkt or Docker.
 
 ## Docker
 

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -69,7 +69,7 @@ If you prefer to start the containers yourself, instead of using `devnet`,
 
 ```sh
 $ sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd3:/var/lib/matchbox/groups:Z quay.io/poseidon/matchbox:latest -address=0.0.0.0:8080 -log-level=debug
-$ sudo docker run --name dnsmasq --cap-add=NET_ADMIN -v $PWD/contrib/dnsmasq/docker0.conf:/etc/dnsmasq.conf:Z quay.io/coreos/dnsmasq -d
+$ sudo docker run --name dnsmasq --cap-add=NET_ADMIN -v $PWD/contrib/dnsmasq/docker0.conf:/etc/dnsmasq.conf:Z quay.io/poseidon/dnsmasq -d
 ```
 
 ## Client VMs

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -167,7 +167,7 @@ Read [network-setup.md](network-setup.md) for the complete range of options. Net
 * May configure subnets, architectures, or specific machines to delegate to matchbox
 * May place matchbox behind a menu entry (timeout and default to matchbox)
 
-If you've never setup a PXE-enabled network before or you're trying to setup a home lab, checkout the [quay.io/coreos/dnsmasq](https://quay.io/repository/coreos/dnsmasq) container image [copy-paste examples](https://github.com/poseidon/matchbox/blob/master/Documentation/network-setup.md#coreosdnsmasq) and see the section about [proxy-DHCP](https://github.com/poseidon/matchbox/blob/master/Documentation/network-setup.md#proxy-dhcp).
+If you've never setup a PXE-enabled network before or you're trying to setup a home lab, checkout the [quay.io/poseidon/dnsmasq](https://quay.io/repository/poseidon/dnsmasq) container image [copy-paste examples](https://github.com/poseidon/matchbox/blob/master/Documentation/network-setup.md#poseidondnsmasq) and see the section about [proxy-DHCP](https://github.com/poseidon/matchbox/blob/master/Documentation/network-setup.md#proxy-dhcp).
 
 ## Boot
 

--- a/Documentation/grub.md
+++ b/Documentation/grub.md
@@ -22,10 +22,10 @@ On Fedora, add the `metal0` interface to the trusted zone in your firewall confi
 $ sudo firewall-cmd --add-interface=metal0 --zone=trusted
 ```
 
-Run the `quay.io/coreos/dnsmasq` container image with rkt or docker.
+Run the `quay.io/poseidon/dnsmasq` container image with rkt or docker.
 
 ```sh
-sudo rkt run --net=metal0:IP=172.18.0.3 quay.io/coreos/dnsmasq \
+sudo rkt run --net=metal0:IP=172.18.0.3 quay.io/poseidon/dnsmasq \
   --caps-retain=CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SETGID,CAP_SETUID,CAP_NET_RAW \
   -- -d -q \
   --dhcp-range=172.18.0.50,172.18.0.99 \
@@ -53,10 +53,10 @@ $ sudo ./scripts/libvirt create-uefi
 
 ## Docker
 
-If you use Docker, run `matchbox` according to [matchbox with Docker](getting-started-docker.md), but mount the [grub](../examples/groups/grub) group example. Then start the `coreos/dnsmasq` Docker image, which bundles a `grub.efi`.
+If you use Docker, run `matchbox` according to [matchbox with Docker](getting-started-docker.md), but mount the [grub](../examples/groups/grub) group example. Then start the `poseidon/dnsmasq` Docker image, which bundles a `grub.efi`.
 
 ```sh
-$ sudo docker run --rm --cap-add=NET_ADMIN quay.io/coreos/dnsmasq -d -q --dhcp-range=172.17.0.43,172.17.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-match=set:efi-bc,option:client-arch,7 --dhcp-boot=tag:efi-bc,grub.efi --dhcp-userclass=set:grub,GRUB2 --dhcp-boot=tag:grub,"(http;matchbox.foo:8080)/grub","172.17.0.2" --log-queries --log-dhcp --dhcp-option=3,172.17.0.1 --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:pxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://matchbox.foo:8080/boot.ipxe --address=/matchbox.foo/172.17.0.2
+$ sudo docker run --rm --cap-add=NET_ADMIN quay.io/poseidon/dnsmasq -d -q --dhcp-range=172.17.0.43,172.17.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-match=set:efi-bc,option:client-arch,7 --dhcp-boot=tag:efi-bc,grub.efi --dhcp-userclass=set:grub,GRUB2 --dhcp-boot=tag:grub,"(http;matchbox.foo:8080)/grub","172.17.0.2" --log-queries --log-dhcp --dhcp-option=3,172.17.0.1 --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:pxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://matchbox.foo:8080/boot.ipxe --address=/matchbox.foo/172.17.0.2
 ```
 
 Create a VM to verify the machine network boots.

--- a/Documentation/machine-lifecycle.md
+++ b/Documentation/machine-lifecycle.md
@@ -2,7 +2,7 @@
 
 ## About boot environment
 
-Physical machines [network boot](network-booting.md) in an network boot environment with DHCP/TFTP/DNS services or with [coreos/dnsmasq](../contrib/dnsmasq).
+Physical machines [network boot](network-booting.md) in an network boot environment with DHCP/TFTP/DNS services or with [poseidon/dnsmasq](../contrib/dnsmasq).
 
 `matchbox` serves iPXE or GRUB configs via HTTP to machines based on Group selectors (e.g. UUID, MAC, region, etc.) and machine Profiles. Kernel and initrd images are fetched and booted with Ignition to install CoreOS Container Linux. The "first boot" Ignition config if fetched and Container Linux is installed.
 

--- a/Documentation/matchbox.md
+++ b/Documentation/matchbox.md
@@ -176,7 +176,7 @@ See the [get-coreos](../scripts/README.md#get-coreos) script to quickly download
 
 ## Network
 
-`matchbox` does not implement or exec a DHCP/TFTP server. Read [network setup](network-setup.md) or use the [coreos/dnsmasq](../contrib/dnsmasq) image if you need a quick DHCP, proxyDHCP, TFTP, or DNS setup.
+`matchbox` does not implement or exec a DHCP/TFTP server. Read [network setup](network-setup.md) or use the [poseidon/dnsmasq](../contrib/dnsmasq) image if you need a quick DHCP, proxyDHCP, TFTP, or DNS setup.
 
 ## Going further
 

--- a/Documentation/network-setup.md
+++ b/Documentation/network-setup.md
@@ -2,7 +2,7 @@
 
 This guide shows how to create a DHCP/TFTP/DNS network boot environment to boot and provision BIOS/PXE, iPXE, or UEFI client machines.
 
-Matchbox serves iPXE scripts over HTTP to serve as the entrypoint for provisioning clusters. It does not implement or exec a DHCP, TFTP, or DNS server. Instead, configure your network environment to point to Matchbox or use the convenient [coreos/dnsmasq](../contrib/dnsmasq) container image (used in local QEMU/KVM setup).
+Matchbox serves iPXE scripts over HTTP to serve as the entrypoint for provisioning clusters. It does not implement or exec a DHCP, TFTP, or DNS server. Instead, configure your network environment to point to Matchbox or use the convenient [poseidon/dnsmasq](../contrib/dnsmasq) container image (used in local QEMU/KVM setup).
 
 *Note*: These are just suggestions. Your network administrator or system administrator should choose the right network setup for your company.
 
@@ -28,7 +28,7 @@ This diagram can point you to the **right section(s)** of this document.
 
 ![Network Setup](img/network-setup-flow.png)
 
-The setup of DHCP, TFTP, and DNS services on a network varies greatly. If you wish to use rkt or Docker to quickly run DHCP, proxyDHCP TFTP, or DNS services, use [coreos/dnsmasq](#coreosdnsmasq).
+The setup of DHCP, TFTP, and DNS services on a network varies greatly. If you wish to use rkt or Docker to quickly run DHCP, proxyDHCP TFTP, or DNS services, use [poseidon/dnsmasq](#poseidondnsmasq).
 
 ## DNS
 
@@ -156,14 +156,14 @@ APPEND dhcp && chain http://matchbox.example.com:8080/boot.ipxe
 
 Add ipxe.lkrn to `/var/lib/tftpboot` (see [iPXE docs](http://ipxe.org/embed)).
 
-## coreos/dnsmasq
+## poseidon/dnsmasq
 
-The [quay.io/coreos/dnsmasq](https://quay.io/repository/coreos/dnsmasq) container image can run DHCP, TFTP, and DNS services via rkt or docker. The image bundles `ipxe.efi`, `undionly.kpxe`, and `grub.efi` for convenience. See [contrib/dnsmasq](../contrib/dnsmasq) for details.
+The [quay.io/poseidon/dnsmasq](https://quay.io/repository/poseidon/dnsmasq) container image can run DHCP, TFTP, and DNS services via rkt or docker. The image bundles `ipxe.efi`, `undionly.kpxe`, and `grub.efi` for convenience. See [contrib/dnsmasq](../contrib/dnsmasq) for details.
 
 Run DHCP, TFTP, and DNS on the host's network:
 
 ```sh
-sudo rkt run --net=host quay.io/coreos/dnsmasq \
+sudo rkt run --net=host quay.io/poseidon/dnsmasq \
   --caps-retain=CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SETGID,CAP_SETUID,CAP_NET_RAW \
   -- -d -q \
   --dhcp-range=192.168.1.3,192.168.1.254 \
@@ -184,7 +184,7 @@ sudo rkt run --net=host quay.io/coreos/dnsmasq \
   --log-dhcp
 ```
 ```sh
-sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/coreos/dnsmasq \
+sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/poseidon/dnsmasq \
   -d -q \
   --dhcp-range=192.168.1.3,192.168.1.254 \
   --enable-tftp --tftp-root=/var/lib/tftpboot \
@@ -206,7 +206,7 @@ sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/coreos/dnsmasq \
 Run a proxy-DHCP and TFTP service on the host's network:
 
 ```sh
-sudo rkt run --net=host quay.io/coreos/dnsmasq \
+sudo rkt run --net=host quay.io/poseidon/dnsmasq \
   --caps-retain=CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SETGID,CAP_SETUID,CAP_NET_RAW \
   -- -d -q \
   --dhcp-range=192.168.1.1,proxy,255.255.255.0 \
@@ -218,7 +218,7 @@ sudo rkt run --net=host quay.io/coreos/dnsmasq \
   --log-dhcp
 ```
 ```sh
-sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/coreos/dnsmasq \
+sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/poseidon/dnsmasq \
   -d -q \
   --dhcp-range=192.168.1.1,proxy,255.255.255.0 \
   --enable-tftp --tftp-root=/var/lib/tftpboot \

--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## Firewall
 
-Running DHCP or proxyDHCP with `coreos/dnsmasq` on a host requires that the Firewall allow DHCP and TFTP (for chainloading) services to run.
+Running DHCP or proxyDHCP with `poseidon/dnsmasq` on a host requires that the Firewall allow DHCP and TFTP (for chainloading) services to run.
 
 ## Port collision
 
@@ -12,8 +12,8 @@ Running DHCP or proxyDHCP can cause port already in use collisions depending on 
 $ sudo lsof -i :67
 ```
 
-Evaluate whether you can configure the existing service or whether you'd like to stop it and test with `coreos/dnsmasq`.
+Evaluate whether you can configure the existing service or whether you'd like to stop it and test with `poseidon/dnsmasq`.
 
 ## No boot filename received
 
-PXE client firmware did not receive a DHCP Offer with PXE-Options after several attempts. If you're using the `coreos/dnsmasq` image with `-d`, each request should log to stdout. Using the wrong `-i` interface is the most common reason DHCP requests are not received. Otherwise, wireshark can be useful for investigating.
+PXE client firmware did not receive a DHCP Offer with PXE-Options after several attempts. If you're using the `poseidon/dnsmasq` image with `-d`, each request should log to stdout. Using the wrong `-i` interface is the most common reason DHCP requests are not received. Otherwise, wireshark can be useful for investigating.

--- a/contrib/dnsmasq/README.md
+++ b/contrib/dnsmasq/README.md
@@ -9,7 +9,7 @@ The image bundles `undionly.kpxe`, `ipxe.efi`, and `grub.efi` (experimental) for
 Run the container image as a DHCP, DNS, and TFTP service.
 
 ```sh
-sudo rkt run --net=host quay.io/coreos/dnsmasq \
+sudo rkt run --net=host quay.io/poseidon/dnsmasq \
   --caps-retain=CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SETGID,CAP_SETUID,CAP_NET_RAW \
   -- -d -q \
   --dhcp-range=192.168.1.3,192.168.1.254 \
@@ -31,7 +31,7 @@ sudo rkt run --net=host quay.io/coreos/dnsmasq \
 ```
 
 ```sh
-sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/coreos/dnsmasq \
+sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/poseidon/dnsmasq \
   -d -q \
   --dhcp-range=192.168.1.3,192.168.1.254 \
   --enable-tftp --tftp-root=/var/lib/tftpboot \
@@ -74,6 +74,6 @@ make docker-image
 Run the image with Docker on the `docker0` bridge (default).
 
 ```
-sudo docker run --rm --cap-add=NET_ADMIN coreos/dnsmasq -d -q
+sudo docker run --rm --cap-add=NET_ADMIN poseidon/dnsmasq -d -q
 ```
 

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -129,7 +129,7 @@ function rkt_create {
     --dns=host \
     --mount volume=config,target=/etc/dnsmasq.conf \
     --volume config,kind=host,source=$DIR/../contrib/dnsmasq/metal0.conf \
-    quay.io/coreos/dnsmasq:v0.5.0 \
+    quay.io/poseidon/dnsmasq:f4623c508ff3fbc467285de1ede61126624b91ac \
     --caps-retain="CAP_NET_ADMIN,CAP_NET_BIND_SERVICE"
 
   status
@@ -181,7 +181,7 @@ function docker_create {
     -d \
     --cap-add=NET_ADMIN \
     -v $PWD/contrib/dnsmasq/docker0.conf:/etc/dnsmasq.conf:Z \
-    quay.io/coreos/dnsmasq:v0.5.0 -d
+    quay.io/poseidon/dnsmasq:f4623c508ff3fbc467285de1ede61126624b91ac -d
 }
 
 function docker_status {


### PR DESCRIPTION
* Use the quay.io/poseidon/dnsmasq image, which receives periodic updates. The coreos/dnsmasq image is outdated

Related: https://github.com/poseidon/matchbox/issues/712