### PR TITLE
Remove rkt tutorials, docs, and scripts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between releases.
 
 ## Latest
 
+* Add `get-fedora-coreos` script ([#763](https://github.com/poseidon/matchbox/pull/763))
+* Update container image base from `alpine:3.9` to `alpine:3.10` ([#761](https://github.com/poseidon/matchbox/pull/761))
+* Remove Kubernetes provisioning examples ([#759](https://github.com/poseidon/matchbox/pull/759))
+* Remove rkt tutorials and docs ([#765](https://github.com/poseidon/matchbox/pull/765))
 
 ## v0.8.0
 

--- a/Documentation/config.md
+++ b/Documentation/config.md
@@ -35,7 +35,6 @@ Configuration arguments can be provided as flags or as environment variables.
 
 ```sh
 $ ./bin/matchbox -version
-$ sudo rkt run quay.io/poseidon/matchbox:latest -- -version
 $ sudo docker run quay.io/poseidon/matchbox:latest -version
 ```
 
@@ -47,12 +46,6 @@ Run the binary.
 $ ./bin/matchbox -address=0.0.0.0:8080 -log-level=debug -data-path=examples -assets-path=examples/assets
 ```
 
-Run the latest ACI with rkt.
-
-```sh
-$ sudo rkt run --mount volume=assets,target=/var/lib/matchbox/assets --volume assets,kind=host,source=$PWD/examples/assets quay.io/poseidon/matchbox:latest -- -address=0.0.0.0:8080 -log-level=debug
-```
-
 Run the latest Docker image.
 
 ```sh
@@ -61,13 +54,7 @@ $ sudo docker run -p 8080:8080 --rm -v $PWD/examples/assets:/var/lib/matchbox/as
 
 ### With examples
 
-Mount `examples` to pre-load the [example](../examples/README.md) machine groups and profiles. Run the container with rkt,
-
-```sh
-$ sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/matchbox/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/poseidon/matchbox:latest -- -address=0.0.0.0:8080 -log-level=debug
-```
-
-or with Docker.
+Mount `examples` to pre-load the [example](../examples/README.md) machine groups and profiles. Run the container.
 
 ```sh
 $ sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z quay.io/poseidon/matchbox:latest -address=0.0.0.0:8080 -log-level=debug
@@ -87,20 +74,6 @@ Clients, such as `bootcmd`, verify the server's certificate with a CA bundle pas
 
 ```sh
 $ ./bin/bootcmd profile list --endpoints 127.0.0.1:8081 --ca-file examples/etc/matchbox/ca.crt --cert-file examples/etc/matchbox/client.crt --key-file examples/etc/matchbox/client.key
-```
-
-### With rkt
-
-Run the ACI with rkt and TLS credentials from `examples/etc/matchbox`.
-
-```sh
-$ sudo rkt run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=$PWD/examples,readOnly=true --mount volume=config,target=/etc/matchbox --volume config,kind=host,source=$PWD/examples/etc/matchbox --mount volume=groups,target=/var/lib/matchbox/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/poseidon/matchbox:latest -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
-```
-
-A `bootcmd` client can call the gRPC API running at the IP used in the rkt example.
-
-```sh
-$ ./bin/bootcmd profile list --endpoints 172.18.0.2:8081 --ca-file examples/etc/matchbox/ca.crt --cert-file examples/etc/matchbox/client.crt --key-file examples/etc/matchbox/client.key
 ```
 
 ### With docker
@@ -126,13 +99,7 @@ $ export MATCHBOX_PASSPHRASE=test
 $ ./bin/matchbox -address=0.0.0.0:8080 -key-ring-path matchbox/sign/fixtures/secring.gpg -data-path=examples -assets-path=examples/assets
 ```
 
-Run the ACI with a test key.
-
-```sh
-$ sudo rkt run --net=metal0:IP=172.18.0.2 --set-env=MATCHBOX_PASSPHRASE=test --mount volume=secrets,target=/secrets --volume secrets,kind=host,source=$PWD/matchbox/sign/fixtures --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=$PWD/examples --mount volume=groups,target=/var/lib/matchbox/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd quay.io/poseidon/matchbox:latest -- -address=0.0.0.0:8080 -key-ring-path secrets/secring.gpg
-```
-
-Run the Docker image with a test key.
+Run the container image with a test key.
 
 ```sh
 $ sudo docker run -p 8080:8080 --rm --env MATCHBOX_PASSPHRASE=test -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z -v $PWD/matchbox/sign/fixtures:/secrets:Z quay.io/poseidon/matchbox:latest -address=0.0.0.0:8080 -log-level=debug -key-ring-path secrets/secring.gpg

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -1,6 +1,6 @@
 # Installation
 
-This guide walks through deploying the `matchbox` service on a Linux host (via RPM, rkt, docker, or binary) or on a Kubernetes cluster.
+This guide walks through deploying the `matchbox` service on a Linux host (via RPM, docker, or binary) or on a Kubernetes cluster.
 
 ## Provisoner
 
@@ -8,10 +8,9 @@ This guide walks through deploying the `matchbox` service on a Linux host (via R
 
 Choose one of the supported installation options:
 
-* [CoreOS Container Linux (rkt)](#coreos-container-linux)
+* [CoreOS Container Linux](#coreos-container-linux)
 * [RPM-based](#rpm-based-distro)
 * [Generic Linux (binary)](#generic-linux)
-* [With rkt](#rkt)
 * [With docker](#docker)
 * [Kubernetes Service](#kubernetes)
 
@@ -51,14 +50,6 @@ dnf install matchbox
 ```
 
 RPMs are not currently available for CentOS and RHEL (due to Go version). CentOS and RHEL users should follow the Generic Linux section below.
-
-### CoreOS Container Linux
-
-On a Container Linux provisioner, rkt run `matchbox` image with the provided systemd unit.
-
-```sh
-$ sudo cp contrib/systemd/matchbox-on-coreos.service /etc/systemd/system/matchbox.service
-```
 
 ### Generic Linux
 
@@ -252,7 +243,7 @@ Review [network setup](https://github.com/poseidon/matchbox/blob/master/Document
 * Point iPXE client machines to the `matchbox` iPXE HTTP endpoint `http://matchbox.example.com:8080/boot.ipxe`
 * Ensure `matchbox.example.com` resolves to your `matchbox` deployment
 
-Poseidon provides [dnsmasq](https://github.com/poseidon/matchbox/tree/master/contrib/dnsmasq) as `quay.io/poseidon/dnsmasq`, if you wish to use rkt or Docker.
+Poseidon provides [dnsmasq](https://github.com/poseidon/matchbox/tree/master/contrib/dnsmasq) as `quay.io/poseidon/dnsmasq`.
 
 ## Docker
 

--- a/Documentation/dev/develop.md
+++ b/Documentation/dev/develop.md
@@ -38,13 +38,7 @@ Run the binary.
 $ ./bin/matchbox -address=0.0.0.0:8080 -log-level=debug -data-path examples -assets-path examples/assets
 ```
 
-Run the container image with rkt, on `metal0`.
-
-```sh
-$ sudo rkt --insecure-options=image run --net=metal0:IP=172.18.0.2 --mount volume=data,target=/var/lib/matchbox --volume data,kind=host,source=$PWD/examples --mount volume=config,target=/etc/matchbox --volume config,kind=host,source=$PWD/examples/etc/matchbox --mount volume=groups,target=/var/lib/matchbox/groups --volume groups,kind=host,source=$PWD/examples/groups/etcd matchbox.aci -- -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
-```
-
-Alternately, run the Docker image on `docker0`.
+Run the Docker image on `docker0`.
 
 ```sh
 $ sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z coreos/matchbox:latest -address=0.0.0.0:8080 -log-level=debug
@@ -52,7 +46,7 @@ $ sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD
 
 ## bootcmd
 
-Run `bootcmd` against the gRPC API of the service running via rkt.
+Run `bootcmd` against the gRPC API of the service.
 
 ```sh
 $ ./bin/bootcmd profile list --endpoints 172.18.0.2:8081 --cacert examples/etc/matchbox/ca.crt

--- a/Documentation/dev/release.md
+++ b/Documentation/dev/release.md
@@ -27,7 +27,6 @@ Travis CI will build the Docker image and push it to Quay.io when the tag is pus
 
 ```sh
 $ sudo docker run quay.io/poseidon/matchbox:$VERSION -version
-$ sudo rkt run --no-store quay.io/poseidon/matchbox:$VERSION -- -version
 ```
 
 ## Github release

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -10,7 +10,7 @@ Install `matchbox` on a dedicated server or Kubernetes cluster. Generate TLS cre
 
 * Installing on [Container Linux / other distros](deployment.md)
 * Installing on [Kubernetes](deployment.md#kubernetes)
-* Running with [rkt](deployment.md#rkt) / [docker](deployment.md#docker)
+* Running with [docker](deployment.md#docker)
 
 Verify the matchbox read-only HTTP endpoints are accessible.
 

--- a/Documentation/grub.md
+++ b/Documentation/grub.md
@@ -12,35 +12,10 @@ Ensure that you've gone through the [matchbox with docker](getting-started-docke
 
 ## Containers
 
-Run `matchbox` with rkt, but mount the [grub](../examples/groups/grub) group example.
-
-## Network
-
-On Fedora, add the `metal0` interface to the trusted zone in your firewall configuration.
+Run `matchbox` according to [matchbox with Docker](getting-started-docker.md), but mount the [grub](../examples/groups/grub) group example. Then start the `poseidon/dnsmasq` Docker image, which bundles a `grub.efi`.
 
 ```sh
-$ sudo firewall-cmd --add-interface=metal0 --zone=trusted
-```
-
-Run the `quay.io/poseidon/dnsmasq` container image with rkt or docker.
-
-```sh
-sudo rkt run --net=metal0:IP=172.18.0.3 quay.io/poseidon/dnsmasq \
-  --caps-retain=CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SETGID,CAP_SETUID,CAP_NET_RAW \
-  -- -d -q \
-  --dhcp-range=172.18.0.50,172.18.0.99 \
-  --enable-tftp \
-  --tftp-root=/var/lib/tftpboot \
-  --dhcp-match=set:efi-bc,option:client-arch,7 \
-  --dhcp-boot=tag:efi-bc,grub.efi \
-  --dhcp-userclass=set:grub,GRUB2 \
-  --dhcp-boot=tag:grub,"(http;matchbox.example.com:8080)/grub","172.18.0.2" \
-  --log-queries \
-  --log-dhcp \
-  --dhcp-userclass=set:ipxe,iPXE \
-  --dhcp-boot=tag:pxe,undionly.kpxe \
-  --dhcp-boot=tag:ipxe,http://matchbox.example.com:8080/boot.ipxe \
-  --address=/matchbox.foo/172.18.0.2
+$ sudo docker run --rm --cap-add=NET_ADMIN quay.io/poseidon/dnsmasq -d -q --dhcp-range=172.17.0.43,172.17.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-match=set:efi-bc,option:client-arch,7 --dhcp-boot=tag:efi-bc,grub.efi --dhcp-userclass=set:grub,GRUB2 --dhcp-boot=tag:grub,"(http;matchbox.foo:8080)/grub","172.17.0.2" --log-queries --log-dhcp --dhcp-option=3,172.17.0.1 --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:pxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://matchbox.foo:8080/boot.ipxe --address=/matchbox.foo/172.17.0.2
 ```
 
 ## Client VM
@@ -49,14 +24,6 @@ Create UEFI VM nodes which have known hardware attributes.
 
 ```sh
 $ sudo ./scripts/libvirt create-uefi
-```
-
-## Docker
-
-If you use Docker, run `matchbox` according to [matchbox with Docker](getting-started-docker.md), but mount the [grub](../examples/groups/grub) group example. Then start the `poseidon/dnsmasq` Docker image, which bundles a `grub.efi`.
-
-```sh
-$ sudo docker run --rm --cap-add=NET_ADMIN quay.io/poseidon/dnsmasq -d -q --dhcp-range=172.17.0.43,172.17.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-match=set:efi-bc,option:client-arch,7 --dhcp-boot=tag:efi-bc,grub.efi --dhcp-userclass=set:grub,GRUB2 --dhcp-boot=tag:grub,"(http;matchbox.foo:8080)/grub","172.17.0.2" --log-queries --log-dhcp --dhcp-option=3,172.17.0.1 --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:pxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://matchbox.foo:8080/boot.ipxe --address=/matchbox.foo/172.17.0.2
 ```
 
 Create a VM to verify the machine network boots.

--- a/Documentation/matchbox.md
+++ b/Documentation/matchbox.md
@@ -2,7 +2,7 @@
 
 `matchbox` is an HTTP and gRPC service that renders signed [Ignition configs](https://coreos.com/ignition/docs/latest/what-is-ignition.html), [cloud-configs](https://coreos.com/os/docs/latest/cloud-config.html), network boot configs, and metadata to machines to create CoreOS Container Linux clusters. `matchbox` maintains **Group** definitions which match machines to *profiles* based on labels (e.g. MAC address, UUID, stage, region). A **Profile** is a named set of config templates (e.g. iPXE, GRUB, Ignition config, Cloud-Config, generic configs). The aim is to use Container Linux's early-boot capabilities to provision Container Linux machines.
 
-Network boot endpoints provide PXE, iPXE, GRUB support. `matchbox` can be deployed as a binary, as an [appc](https://github.com/appc/spec) container with rkt, or as a Docker container.
+Network boot endpoints provide PXE, iPXE, GRUB support. `matchbox` can be run a binary or as a container.
 
 ![Bootcfg Overview](img/overview.png)
 

--- a/Documentation/network-setup.md
+++ b/Documentation/network-setup.md
@@ -28,7 +28,7 @@ This diagram can point you to the **right section(s)** of this document.
 
 ![Network Setup](img/network-setup-flow.png)
 
-The setup of DHCP, TFTP, and DNS services on a network varies greatly. If you wish to use rkt or Docker to quickly run DHCP, proxyDHCP TFTP, or DNS services, use [poseidon/dnsmasq](#poseidondnsmasq).
+The setup of DHCP, TFTP, and DNS services on a network varies greatly. If you wish to use Docker to quickly run DHCP, proxyDHCP TFTP, or DNS services, use [poseidon/dnsmasq](#poseidondnsmasq).
 
 ## DNS
 
@@ -158,31 +158,10 @@ Add ipxe.lkrn to `/var/lib/tftpboot` (see [iPXE docs](http://ipxe.org/embed)).
 
 ## poseidon/dnsmasq
 
-The [quay.io/poseidon/dnsmasq](https://quay.io/repository/poseidon/dnsmasq) container image can run DHCP, TFTP, and DNS services via rkt or docker. The image bundles `ipxe.efi`, `undionly.kpxe`, and `grub.efi` for convenience. See [contrib/dnsmasq](../contrib/dnsmasq) for details.
+The [quay.io/poseidon/dnsmasq](https://quay.io/repository/poseidon/dnsmasq) container image can run DHCP, TFTP, and DNS services via docker. The image bundles `ipxe.efi`, `undionly.kpxe`, and `grub.efi` for convenience. See [contrib/dnsmasq](../contrib/dnsmasq) for details.
 
 Run DHCP, TFTP, and DNS on the host's network:
 
-```sh
-sudo rkt run --net=host quay.io/poseidon/dnsmasq \
-  --caps-retain=CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SETGID,CAP_SETUID,CAP_NET_RAW \
-  -- -d -q \
-  --dhcp-range=192.168.1.3,192.168.1.254 \
-  --enable-tftp \
-  --tftp-root=/var/lib/tftpboot \
-  --dhcp-match=set:bios,option:client-arch,0 \
-  --dhcp-boot=tag:bios,undionly.kpxe \
-  --dhcp-match=set:efi32,option:client-arch,6 \
-  --dhcp-boot=tag:efi32,ipxe.efi \
-  --dhcp-match=set:efibc,option:client-arch,7 \
-  --dhcp-boot=tag:efibc,ipxe.efi \
-  --dhcp-match=set:efi64,option:client-arch,9 \
-  --dhcp-boot=tag:efi64,ipxe.efi \
-  --dhcp-userclass=set:ipxe,iPXE \
-  --dhcp-boot=tag:ipxe,http://matchbox.example.com:8080/boot.ipxe \ 
-  --address=/matchbox.example.com/192.168.1.2 \
-  --log-queries \
-  --log-dhcp
-```
 ```sh
 sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/poseidon/dnsmasq \
   -d -q \
@@ -205,18 +184,6 @@ sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/poseidon/dnsmasq \
 
 Run a proxy-DHCP and TFTP service on the host's network:
 
-```sh
-sudo rkt run --net=host quay.io/poseidon/dnsmasq \
-  --caps-retain=CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SETGID,CAP_SETUID,CAP_NET_RAW \
-  -- -d -q \
-  --dhcp-range=192.168.1.1,proxy,255.255.255.0 \
-  --enable-tftp --tftp-root=/var/lib/tftpboot \
-  --dhcp-userclass=set:ipxe,iPXE \
-  --pxe-service=tag:#ipxe,x86PC,"PXE chainload to iPXE",undionly.kpxe \
-  --pxe-service=tag:ipxe,x86PC,"iPXE",http://matchbox.example.com:8080/boot.ipxe \
-  --log-queries \
-  --log-dhcp
-```
 ```sh
 sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/poseidon/dnsmasq \
   -d -q \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 * Installation
   * Installing on [Container Linux / other distros](Documentation/deployment.md)
   * Installing on [Kubernetes](Documentation/deployment.md#kubernetes)
-  * Running with [rkt](Documentation/deployment.md#rkt) / [docker](Documentation/deployment.md#docker)
+  * Running with [docker](Documentation/deployment.md#docker)
 * [Network Setup](Documentation/network-setup.md)
 
 ### Tutorials
@@ -34,7 +34,7 @@
 
 ## Contrib
 
-* [dnsmasq](contrib/dnsmasq/README.md) - Run DHCP, TFTP, and DNS services with docker or rkt
+* [dnsmasq](contrib/dnsmasq/README.md) - Run DHCP, TFTP, and DNS services as a container
 * [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox) - Terraform provider plugin for Matchbox
 
 [docs]: https://coreos.com/matchbox/docs/latest

--- a/contrib/dnsmasq/README.md
+++ b/contrib/dnsmasq/README.md
@@ -9,28 +9,6 @@ The image bundles `undionly.kpxe`, `ipxe.efi`, and `grub.efi` (experimental) for
 Run the container image as a DHCP, DNS, and TFTP service.
 
 ```sh
-sudo rkt run --net=host quay.io/poseidon/dnsmasq \
-  --caps-retain=CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SETGID,CAP_SETUID,CAP_NET_RAW \
-  -- -d -q \
-  --dhcp-range=192.168.1.3,192.168.1.254 \
-  --enable-tftp \
-  --tftp-root=/var/lib/tftpboot \
-  --dhcp-match=set:bios,option:client-arch,0 \
-  --dhcp-boot=tag:bios,undionly.kpxe \
-  --dhcp-match=set:efi32,option:client-arch,6 \
-  --dhcp-boot=tag:efi32,ipxe.efi \
-  --dhcp-match=set:efibc,option:client-arch,7 \
-  --dhcp-boot=tag:efibc,ipxe.efi \
-  --dhcp-match=set:efi64,option:client-arch,9 \
-  --dhcp-boot=tag:efi64,ipxe.efi \
-  --dhcp-userclass=set:ipxe,iPXE \
-  --dhcp-boot=tag:ipxe,http://matchbox.example.com:8080/boot.ipxe \
-  --address=/matchbox.example.com/192.168.1.2 \
-  --log-queries \
-  --log-dhcp
-```
-
-```sh
 sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/poseidon/dnsmasq \
   -d -q \
   --dhcp-range=192.168.1.3,192.168.1.254 \
@@ -50,7 +28,7 @@ sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/poseidon/dnsmasq \
   --log-dhcp
 ```
 
-Press ^] three times to stop the rkt pod. Press ctrl-C to stop the Docker container.
+Press ctrl-C to stop the Docker container.
 
 ## Configuration Flags
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,10 +28,7 @@ Create QEMU/KVM VMs which are configured to boot from the network. The `scripts/
     $ sudo ./scripts/libvirt
     USAGE: libvirt <command>
     Commands:
-        create      create QEMU/KVM nodes on a rkt CNI metal0 bridge
-        create-rkt  create QEMU/KVM nodes on a rkt CNI metal0 bridge
-        create-docker   create QEMU/KVM nodes on the docker0 bridge
-        create-uefi create UEFI QEMU/KVM nodes on the rkt CNI metal0 bridge
+        create      create QEMU/KVM nodes on the docker0 bridge
         start       start the QEMU/KVM nodes
         reboot      reboot the QEMU/KVM nodes
         shutdown    shutdown the QEMU/KVM nodes

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -8,14 +8,12 @@ set -u
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 EXAMPLE=${2:-}
-# Local Container Runtime (docker or rkt)
+# Local Container Runtime (docker)
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 BRIDGE=metal0
 ASSETS_DIR="${ASSETS_DIR:-$PWD/examples/assets}"
 CONFIG_DIR="${CONFIG_DIR:-$PWD/examples/etc/matchbox}"
 
-COREOS_CHANNEL=stable
-COREOS_VERSION=1967.3.0
 MATCHBOX_ARGS=""
 
 if [ "$EUID" -ne 0 ]
@@ -49,7 +47,6 @@ function usage {
 
 function create {
   case "$CONTAINER_RUNTIME" in
-    "rkt") rkt_create;;
     "docker") docker_create;;
     *) docker_create;;
   esac
@@ -57,7 +54,6 @@ function create {
 
 function status {
   case "$CONTAINER_RUNTIME" in
-    "rkt") rkt_status;;
     "docker") docker_status;;
     *) docker_status;;
   esac
@@ -65,90 +61,9 @@ function status {
 
 function destroy {
   case "$CONTAINER_RUNTIME" in
-    "rkt") rkt_destroy;;
     "docker") docker_destroy;;
     *) docker_destroy;;
   esac
-}
-
-function rkt_check {
-  # SELinux, if present, it cannot be in Enforcing mode
-  if [ $(getenforce) == 'Enforcing' ]; then
-    echo "SELinux must be in permissive mode: 'setenforce Permissive'"
-    exit 1
-  fi
-
-  if [ ! -d $ASSETS_DIR/coreos/$COREOS_VERSION ]; then
-    echo "Most examples use CoreOS $COREOS_CHANNEL $COREOS_VERSION. You may wish to download it with './scripts/get-coreos $COREOS_CHANNEL $COREOS_VERSION'."
-  fi
-}
-
-function rkt_create {
-  rkt_check
-
-  if [ -z "$EXAMPLE" ]; then
-    echo "Starting matchbox"
-  else
-    echo "Starting matchbox configured to boot $EXAMPLE"
-  fi
-
-  if [ -z "$EXAMPLE" ]; then
-    # Mount a data volume with assets and enable gRPC
-    MATCHBOX_ARGS="-rpc-address=0.0.0.0:8081"
-    DATA_MOUNT="--volume data,kind=host,source=$(mktemp -d) \
-    --mount volume=assets,target=/var/lib/matchbox/assets \
-    --volume assets,kind=host,source=$ASSETS_DIR,readOnly=true"
-  else
-    # Mount the given EXAMPLE
-    DATA_MOUNT="--volume data,kind=host,source=$PWD/examples \
-    --mount volume=groups,target=/var/lib/matchbox/groups \
-    --volume groups,kind=host,source=$DIR/../examples/groups/$EXAMPLE \
-    --mount volume=assets,target=/var/lib/matchbox/assets \
-    --volume assets,kind=host,source=$ASSETS_DIR,readOnly=true"
-  fi
-
-  rkt rm --uuid-file=/var/run/matchbox-pod.uuid > /dev/null 2>&1
-  systemd-run --unit=dev-matchbox \
-    rkt run \
-    --uuid-file-save=/var/run/matchbox-pod.uuid \
-    --trust-keys-from-https \
-    --net=metal0:IP=172.18.0.2 \
-    --mount volume=config,target=/etc/matchbox \
-    --volume config,kind=host,source=$CONFIG_DIR,readOnly=true \
-    --mount volume=data,target=/var/lib/matchbox \
-    $DATA_MOUNT \
-    quay.io/poseidon/matchbox:v0.8.0 -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
-
-  echo "Starting dnsmasq to provide DHCP/TFTP/DNS services"
-  rkt rm --uuid-file=/var/run/dnsmasq-pod.uuid > /dev/null 2>&1
-  systemd-run --unit=dev-dnsmasq \
-    rkt run \
-    --uuid-file-save=/var/run/dnsmasq-pod.uuid \
-    --trust-keys-from-https \
-    --net=metal0:IP=172.18.0.3 \
-    --dns=host \
-    --mount volume=config,target=/etc/dnsmasq.conf \
-    --volume config,kind=host,source=$DIR/../contrib/dnsmasq/metal0.conf \
-    quay.io/poseidon/dnsmasq:f4623c508ff3fbc467285de1ede61126624b91ac \
-    --caps-retain="CAP_NET_ADMIN,CAP_NET_BIND_SERVICE"
-
-  status
-}
-
-function rkt_status {
-  echo ""
-  systemctl status dev-matchbox --lines=0 --no-pager
-  systemctl status dev-dnsmasq --lines=0 --no-pager
-  echo ""
-  echo "Use 'systemctl status dev-matchbox' or 'systemctl status dev-dnsmasq' to check individual statuses."
-  echo "Use 'journalctl -f -u dev-matchbox', etc. to tail the logs."
-}
-
-function rkt_destroy {
-  rkt stop --uuid-file=/var/run/matchbox-pod.uuid
-  rkt stop --uuid-file=/var/run/dnsmasq-pod.uuid
-  systemctl reset-failed dev-matchbox > /dev/null 2>&1
-  systemctl reset-failed dev-dnsmasq > /dev/null 2>&1
 }
 
 function docker_create {

--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -12,9 +12,6 @@ fi
 function main {
   case "$1" in
     "create") create_docker;;
-    "create-docker") create_docker;;
-    "create-rkt") create_rkt;;
-    "create-uefi") create_uefi;;
     "start") start;;
     "reboot") reboot;;
     "shutdown") shutdown;;
@@ -30,10 +27,7 @@ function main {
 function usage {
   echo "USAGE: ${0##*/} <command>"
   echo "Commands:"
-  echo -e "\tcreate\t\tcreate QEMU/KVM nodes on a rkt CNI metal0 bridge"
-  echo -e "\tcreate-rkt\tcreate QEMU/KVM nodes on a rkt CNI metal0 bridge"
-  echo -e "\tcreate-docker\tcreate QEMU/KVM nodes on the docker0 bridge"
-  echo -e "\tcreate-uefi\tcreate UEFI QEMU/KVM nodes on the docker0 bridge"
+  echo -e "\tcreate\t\tcreate QEMU/KVM nodes on the docker0 bridge"
   echo -e "\tstart\t\tstart the QEMU/KVM nodes"
   echo -e "\treboot\t\treboot the QEMU/KVM nodes"
   echo -e "\tshutdown\tshutdown the QEMU/KVM nodes"
@@ -56,18 +50,6 @@ function create_docker {
   virt-install --name $NODE1_NAME --network=bridge:docker0,mac=$NODE1_MAC $COMMON_VIRT_OPTS --boot=hd,network
   virt-install --name $NODE2_NAME --network=bridge:docker0,mac=$NODE2_MAC $COMMON_VIRT_OPTS --boot=hd,network
   virt-install --name $NODE3_NAME --network=bridge:docker0,mac=$NODE3_MAC $COMMON_VIRT_OPTS --boot=hd,network
-}
-
-function create_rkt {
-  virt-install --name $NODE1_NAME --network=bridge:metal0,mac=$NODE1_MAC $COMMON_VIRT_OPTS --boot=hd,network
-  virt-install --name $NODE2_NAME --network=bridge:metal0,mac=$NODE2_MAC $COMMON_VIRT_OPTS --boot=hd,network
-  virt-install --name $NODE3_NAME --network=bridge:metal0,mac=$NODE3_MAC $COMMON_VIRT_OPTS --boot=hd,network
-}
-
-function create_uefi {
-  virt-install --name $NODE1_NAME --network=bridge=docker0,model=e1000,mac=$NODE1_MAC $COMMON_VIRT_OPTS --boot=hd,uefi,network
-  virt-install --name $NODE2_NAME --network=bridge=docker0,model=e1000,mac=$NODE2_MAC $COMMON_VIRT_OPTS --boot=hd,uefi,network
-  virt-install --name $NODE3_NAME --network=bridge=docker0,model=e1000,mac=$NODE3_MAC $COMMON_VIRT_OPTS --boot=hd,uefi,network
 }
 
 nodes=(node1 node2 node3)


### PR DESCRIPTION
* rkt achieved its mission creating the OCI standard, pluggable runtimes, and prevented Docker world domination. We can now proceed with disarmament
* Few, if any, developers still use rkt locally