### PR TITLE
Update Go versions for build and test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: required
 services:
   - docker
 go:
-  - "1.10.x"
   - "1.11.x"
-  - "1.11.7"
   - "1.12.x"
+  - "1.12.10"
+  - "1.13.x"
 install:
   - go get golang.org/x/lint/golint
 script:
@@ -17,13 +17,13 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      go: '1.11.7'
+      go: '1.12.10'
   - provider: script
     script: contrib/dnsmasq/travis-deploy
     skip_cleanup: true
     on:
       branch: dnsmasq
       # pick one, so travis deploys once
-      go: '1.10.x'
+      go: '1.11.x'
 notifications:
   email: change

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Notable changes between releases.
 
 * Add `get-fedora-coreos` script ([#763](https://github.com/poseidon/matchbox/pull/763))
 * Update container image base from `alpine:3.9` to `alpine:3.10` ([#761](https://github.com/poseidon/matchbox/pull/761))
+* Build matchbox with Go v1.12.10 for images and binaries ([#766](https://github.com/poseidon/matchbox/pull/766))
 * Remove Kubernetes provisioning examples ([#759](https://github.com/poseidon/matchbox/pull/759))
 * Remove rkt tutorials and docs ([#765](https://github.com/poseidon/matchbox/pull/765))
 


### PR DESCRIPTION
* Build matchbox with Go v1.12.10
* Add go v1.13.x to the test matrix
* Drop Go v1.10.x from the test matrix