### PR TITLE
Update Go version from v1.12.10 to v1.13.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
 go:
   - "1.11.x"
   - "1.12.x"
-  - "1.12.10"
   - "1.13.x"
+  - "1.13.4"
 install:
   - go get golang.org/x/lint/golint
 script:
@@ -17,7 +17,7 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      go: '1.12.10'
+      go: '1.13.4'
   - provider: script
     script: contrib/dnsmasq/travis-deploy
     skip_cleanup: true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,12 @@ Notable changes between releases.
 
 ## Latest
 
-* Publish docs to [https://matchbox.psdn.io](https://matchbox.psdn.io/)
-* Add `get-fedora-coreos` script ([#763](https://github.com/poseidon/matchbox/pull/763))
+## v0.8.1
+
+* Publish docs to [https://matchbox.psdn.io](https://matchbox.psdn.io/) ([#769](https://github.com/poseidon/matchbox/pull/769))
+* Update Go version from v1.11.7 to v1.13.4 ([#766](https://github.com/poseidon/matchbox/pull/766), [#770](https://github.com/poseidon/matchbox/pull/770))
 * Update container image base from `alpine:3.9` to `alpine:3.10` ([#761](https://github.com/poseidon/matchbox/pull/761))
-* Build matchbox with Go v1.12.10 for images and binaries ([#766](https://github.com/poseidon/matchbox/pull/766))
+* Include `get-fedora-coreos` convenience script ([#763](https://github.com/poseidon/matchbox/pull/763))
 * Remove Kubernetes provisioning examples ([#759](https://github.com/poseidon/matchbox/pull/759))
 * Remove rkt tutorials and docs ([#765](https://github.com/poseidon/matchbox/pull/765))
 


### PR DESCRIPTION
* Use Go version v1.13.4 in Travis image builds and for building release binaries