### PR TITLE
Fix links to Documentation to new docs directory

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -237,7 +237,7 @@ For large production environments, use a cache proxy or mirror suitable for your
 
 ## Network
 
-Review [network setup](https://github.com/poseidon/matchbox/blob/master/Documentation/network-setup.md) with your network administrator to set up DHCP, TFTP, and DNS services on your network. At a high level, your goals are to:
+Review [network setup](https://github.com/poseidon/matchbox/blob/master/docs/network-setup.md) with your network administrator to set up DHCP, TFTP, and DNS services on your network. At a high level, your goals are to:
 
 * Chainload PXE firmwares to iPXE
 * Point iPXE client machines to the `matchbox` iPXE HTTP endpoint `http://matchbox.example.com:8080/boot.ipxe`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,7 +167,7 @@ Read [network-setup.md](network-setup.md) for the complete range of options. Net
 * May configure subnets, architectures, or specific machines to delegate to matchbox
 * May place matchbox behind a menu entry (timeout and default to matchbox)
 
-If you've never setup a PXE-enabled network before or you're trying to setup a home lab, checkout the [quay.io/poseidon/dnsmasq](https://quay.io/repository/poseidon/dnsmasq) container image [copy-paste examples](https://github.com/poseidon/matchbox/blob/master/Documentation/network-setup.md#poseidondnsmasq) and see the section about [proxy-DHCP](https://github.com/poseidon/matchbox/blob/master/Documentation/network-setup.md#proxy-dhcp).
+If you've never setup a PXE-enabled network before or you're trying to setup a home lab, checkout the [quay.io/poseidon/dnsmasq](https://quay.io/repository/poseidon/dnsmasq) container image [copy-paste examples](https://github.com/poseidon/matchbox/blob/master/docs/network-setup.md#poseidondnsmasq) and see the section about [proxy-DHCP](https://github.com/poseidon/matchbox/blob/master/docs/network-setup.md#proxy-dhcp).
 
 ## Boot
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ These examples use [Terraform](https://www.terraform.io/intro/) as a client to M
 
 ### Customization
 
-You are encouraged to look through the examples and Terraform modules. Implement your own profiles or package them as modules to meet your needs. We've just provided a starting point. Learn more about [matchbox](../Documentation/matchbox.md) and [Container Linux configs](../Documentation/container-linux-config.md).
+You are encouraged to look through the examples and Terraform modules. Implement your own profiles or package them as modules to meet your needs. We've just provided a starting point. Learn more about [matchbox](../docs/matchbox.md) and [Container Linux configs](../docs/container-linux-config.md).
 
 ## Manual Examples
 

--- a/examples/terraform/etcd3-install/README.md
+++ b/examples/terraform/etcd3-install/README.md
@@ -4,15 +4,15 @@ The `etcd3-install` example shows how to use matchbox to network boot and provis
 
 ## Requirements
 
-Follow the getting started [tutorial](../../../Documentation/getting-started.md) to learn about matchbox and set up an environment that meets the requirements:
+Follow the getting started [tutorial](../../../docs/getting-started.md) to learn about matchbox and set up an environment that meets the requirements:
 
-* Matchbox v0.6+ [installation](../../../Documentation/deployment.md) with gRPC API enabled
+* Matchbox v0.6+ [installation](../../../docs/deployment.md) with gRPC API enabled
 * Matchbox provider credentials `client.crt`, `client.key`, and `ca.crt`
-* PXE [network boot](../../../Documentation/network-setup.md) environment
+* PXE [network boot](../../../docs/network-setup.md) environment
 * Terraform v0.9+ and [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox) installed locally on your system
 * 3 machines with known DNS names and MAC addresses
 
-If you prefer to provision QEMU/KVM VMs on your local Linux machine, set up the matchbox [development environment](../../../Documentation/getting-started-docker.md).
+If you prefer to provision QEMU/KVM VMs on your local Linux machine, set up the matchbox [development environment](../../../docs/getting-started-docker.md).
 
 ```sh
 sudo ./scripts/devnet create
@@ -37,7 +37,7 @@ ssh_authorized_key = "ADD ME"
 
 Configs in `etcd3-install` configure the matchbox provider, define profiles (e.g. `cached-container-linux-install`, `etcd3`), and define 3 groups which match machines by MAC address to a profile. These resources declare that the machines should PXE boot, install Container Linux to disk, and provision themselves into peers in a 3-node etcd3 cluster.
 
-Note: The `cached-container-linux-install` profile will PXE boot and install Container Linux from matchbox [assets](https://github.com/poseidon/matchbox/blob/master/Documentation/api.md#assets). If you have not populated the assets cache, use the `container-linux-install` profile to use public images (slower).
+Note: The `cached-container-linux-install` profile will PXE boot and install Container Linux from matchbox [assets](https://github.com/poseidon/matchbox/blob/master/docs/api.md#assets). If you have not populated the assets cache, use the `container-linux-install` profile to use public images (slower).
 
 ### Optional
 
@@ -100,4 +100,4 @@ $ etcdctl get /message
 
 ## Going Further
 
-Learn more about [matchbox](../../../Documentation/matchbox.md) or explore the other [example](../) clusters.
+Learn more about [matchbox](../../../docs/matchbox.md) or explore the other [example](../) clusters.

--- a/examples/terraform/modules/README.md
+++ b/examples/terraform/modules/README.md
@@ -30,4 +30,4 @@ Available modules:
 
 ## Customization
 
-You are encouraged to look through the examples and modules. Implement your own profiles or package them as modules to meet your needs. We've just provided a starting point. Learn more about [matchbox](../../Documentation/matchbox.md) and [Container Linux configs](../../Documentation/container-linux-config.md).
+You are encouraged to look through the examples and modules. Implement your own profiles or package them as modules to meet your needs. We've just provided a starting point. Learn more about [matchbox](../../docs/matchbox.md) and [Container Linux configs](../../docs/container-linux-config.md).

--- a/scripts/dev/release-files
+++ b/scripts/dev/release-files
@@ -19,6 +19,8 @@ cp README.md $DEST
 # scripts
 mkdir -p $SCRIPTS/tls
 cp scripts/get-coreos $SCRIPTS
+cp scripts/get-coreos $SCRIPTS
+cp scripts/get-coreos $SCRIPTS
 cp scripts/tls/README.md $SCRIPTS/tls
 cp scripts/tls/cert-gen $SCRIPTS/tls
 cp scripts/tls/openssl.conf $SCRIPTS/tls
@@ -33,5 +35,5 @@ cp -r examples/{cloud,groups,ignition,profiles,README.md} $DEST/examples
 
 # docs
 mkdir -p $DEST/docs
-cp -r Documentation $DEST/docs
+cp -r docs $DEST/docs
 

--- a/scripts/tls/README.md
+++ b/scripts/tls/README.md
@@ -1,6 +1,6 @@
 ## gRPC TLS Generation
 
-The Matchbox gRPC API allows clients (`terraform-provider-matchbox`) to create and update Matchbox resources. TLS credentials are used for client authentication and to establish a secure communication channel. When the gRPC API is [enabled](../../Documentation/deployment.md#customization), the server requires a TLS server certificate, key, and CA certificate ([locations](../../Documentation/config.md#files-and-directories)).
+The Matchbox gRPC API allows clients (`terraform-provider-matchbox`) to create and update Matchbox resources. TLS credentials are used for client authentication and to establish a secure communication channel. When the gRPC API is [enabled](../../docs/deployment.md#customization), the server requires a TLS server certificate, key, and CA certificate ([locations](../../docs/config.md#files-and-directories)).
 
 The `cert-gen` helper script generates a self-signed CA, server certificate, and client certificate. **Prefer your organization's PKI, if possible**
 
@@ -39,7 +39,7 @@ $ sudo cp ca.crt server.crt server.key /etc/matchbox
 
 Save `client.crt`, `client.key`, and `ca.crt` for later use (e.g. `~/.matchbox`).
 
-*If you are using the local Matchbox [development environment](../../Documentation/getting-started-docker.md), move server credentials to `examples/etc/matchbox`.*
+*If you are using the local Matchbox [development environment](../../docs/getting-started-docker.md), move server credentials to `examples/etc/matchbox`.*
 
 ## Inspect
 


### PR DESCRIPTION
* Docs were moved to `docs` in https://github.com/poseidon/matchbox/pull/769