### PR TITLE
Disable Go modules while installing golint tool on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
   - "1.13.x"
   - "1.13.4"
 install:
-  - go get golang.org/x/lint/golint
+  - GO111MODULE=off go get golang.org/x/lint/golint
 script:
   - make
 deploy:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Notable changes between releases.
 
 ## Latest
 
-## v0.8.2
+## v0.8.3
 
 * Publish docs to [https://matchbox.psdn.io](https://matchbox.psdn.io/) ([#769](https://github.com/poseidon/matchbox/pull/769))
 * Update Go version from v1.11.7 to v1.13.4 ([#766](https://github.com/poseidon/matchbox/pull/766), [#770](https://github.com/poseidon/matchbox/pull/770))
@@ -13,9 +13,12 @@ Notable changes between releases.
 * Remove Kubernetes provisioning examples ([#759](https://github.com/poseidon/matchbox/pull/759))
 * Remove rkt tutorials and docs ([#765](https://github.com/poseidon/matchbox/pull/765))
 
-## v0.8.1
+## v0.8.1 - v0.8.2
 
-This release was not built correctly and is skipped.
+Releases `v0.8.1` and `v0.8.2` were not built cleanly
+
+* Release tags and container images have been removed
+* Caused by go get golint (module-aware) mutating `go.mod` on Travis (see [#775](https://github.com/poseidon/matchbox/pull/775))
 
 ## v0.8.0
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ all: build test vet lint fmt
 build: clean bin/matchbox
 
 bin/%:
-	git describe --tags --match=v* --always --dirty --debug
 	@go build -o bin/$* -ldflags $(LD_FLAGS) $(REPO)/cmd/$*
 
 .PHONY: test


### PR DESCRIPTION
* Travis creates a Go v1.13.4 environment, checks out the source repo, and _then_ executes the `install` block to install `golint`
* With module-aware Go, this means installing `golint` caused a diff, before the Matchbox `make` target was invoked. Builds were correctly identified as "dirty" as a result
* Release tags v0.8.1 and v0.8.2 have been removed to avoid any confusion. Container images with binaries considered dirty have been removed as well. These tags and images only existed for a few minutes, the problem was flagged during the release process.
* Details: https://github.com/poseidon/matchbox/pull/773#issuecomment-557846875