### PR TITLE
Set `go 1.13` in go.mod to avoid a diff at build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Notable changes between releases.
 Releases `v0.8.1` and `v0.8.2` were not built cleanly
 
 * Release tags and container images have been removed
-* Caused by go get golint (module-aware) mutating `go.mod` on Travis (see [#775](https://github.com/poseidon/matchbox/pull/775))
+* Caused by go get golint (module-aware) mutating `go.mod` on Travis (see [#775](https://github.com/poseidon/matchbox/pull/775), [#777](https://github.com/poseidon/matchbox/pull/777))
 
 ## v0.8.0
 

--- a/go.mod
+++ b/go.mod
@@ -28,3 +28,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.0.0-20151201162745-f7716cbe52ba // indirect
 )
+
+go 1.13


### PR DESCRIPTION
* `go` modifies `go.mod` during the build to add `go 1.13`, which causes the build to be considered dirty (Travis: https://travis-ci.org/poseidon/matchbox/jobs/616382705)