### PR TITLE
cert-gen drop -extensions flags as they don't work in all places

### DIFF
--- a/scripts/tls/cert-gen
+++ b/scripts/tls/cert-gen
@@ -21,7 +21,7 @@ echo 1000 > serial
 # CA private key (unencrypted)
 openssl genrsa -out ca.key 4096
 # Certificate Authority (self-signed certificate)
-openssl req -config openssl.conf -new -x509 -days 3650 -sha256 -key ca.key -extensions v3_ca -out ca.crt -subj "/CN=fake-ca"
+openssl req -config openssl.conf -new -x509 -days 3650 -sha256 -key ca.key -out ca.crt -subj "/CN=fake-ca"
 
 # End-entity certificates
 
@@ -30,14 +30,14 @@ openssl genrsa -out server.key 2048
 # Server certificate signing request (CSR)
 openssl req -config openssl.conf -new -sha256 -key server.key -out server.csr -subj "/CN=fake-server"
 # Certificate Authority signs CSR to grant a certificate
-openssl ca -batch -config openssl.conf -extensions server_cert -days 365 -notext -md sha256 -in server.csr -out server.crt -cert ca.crt -keyfile ca.key
+openssl ca -batch -config openssl.conf -days 365 -notext -md sha256 -in server.csr -out server.crt -cert ca.crt -keyfile ca.key
 
 # Client private key (unencrypted)
 openssl genrsa -out client.key 2048
 # Signed client certificate signing request (CSR)
 openssl req -config openssl.conf -new -sha256 -key client.key -out client.csr -subj "/CN=fake-client"
 # Certificate Authority signs CSR to grant a certificate
-openssl ca -batch -config openssl.conf -extensions usr_cert -days 365 -notext -md sha256 -in client.csr -out client.crt -cert ca.crt -keyfile ca.key
+openssl ca -batch -config openssl.conf -days 365 -notext -md sha256 -in client.csr -out client.crt -cert ca.crt -keyfile ca.key
 
 # Remove CSR's
 rm *.csr


### PR DESCRIPTION
I had issues running `cert-gen` on both my raspberrypi + macos laptop until I removed the `-extension` flags.