### PR TITLE
Update base container image from alpine:3.10 to alpine:3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.11
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 COPY bin/matchbox /matchbox
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,20 @@ lint:
 fmt:
 	@test -z $$(go fmt ./...)
 
+.PHONY: image
+image:
+	@buildah bud -t $(LOCAL_REPO):$(VERSION) .
+	@buildah tag $(LOCAL_REPO):$(VERSION) $(LOCAL_REPO):latest
+
+.PHONY: push
+push:
+	@buildah tag $(LOCAL_REPO):$(VERSION) $(IMAGE_REPO):$(VERSION)
+	@buildah tag $(LOCAL_REPO):$(VERSION) $(IMAGE_REPO):latest
+	@buildah push docker://$(IMAGE_REPO):$(VERSION)
+	@buildah push docker://$(IMAGE_REPO):latest
+
+# for travis only
+
 .PHONY: docker-image
 docker-image:
 	@sudo docker build --rm=true -t $(LOCAL_REPO):$(VERSION) .

--- a/contrib/dnsmasq/Dockerfile
+++ b/contrib/dnsmasq/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.11
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 RUN apk -U add dnsmasq curl
 COPY tftpboot /var/lib/tftpboot

--- a/contrib/dnsmasq/Makefile
+++ b/contrib/dnsmasq/Makefile
@@ -1,8 +1,8 @@
 DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 VERSION=$(shell git rev-parse HEAD)
 
-IMAGE_REPO=poseidon/dnsmasq
-QUAY_REPO=quay.io/poseidon/dnsmasq
+LOCAL_REPO=poseidon/dnsmasq
+IMAGE_REPO=quay.io/poseidon/dnsmasq
 
 .PHONY: all
 all: docker-image
@@ -11,14 +11,28 @@ all: docker-image
 tftp:
 	@$(DIR)/get-tftp-files
 
+.PHONY: image
+image:
+	@buildah bud -t $(LOCAL_REPO):$(VERSION) .
+	@buildah tag $(LOCAL_REPO):$(VERSION) $(LOCAL_REPO):latest
+
+.PHONY: push
+push:
+	@buildah tag $(LOCAL_REPO):$(VERSION) $(IMAGE_REPO):$(VERSION)
+	@buildah tag $(LOCAL_REPO):$(VERSION) $(IMAGE_REPO):latest
+	@buildah push docker://$(IMAGE_REPO):$(VERSION)
+	@buildah push docker://$(IMAGE_REPO):latest
+
+# for travis-only
+
 .PHONY: docker-image
 docker-image: tftp
-	@sudo docker build --rm=true -t $(IMAGE_REPO):$(VERSION) .
-	@sudo docker tag $(IMAGE_REPO):$(VERSION) $(IMAGE_REPO):latest
+	@sudo docker build --rm=true -t $(LOCAL_REPO):$(VERSION) .
+	@sudo docker tag $(LOCAL_REPO):$(VERSION) $(LOCAL_REPO):latest
 
 .PHONY: docker-push
 docker-push:
-	@sudo docker tag $(IMAGE_REPO):$(VERSION) $(QUAY_REPO):latest
-	@sudo docker tag $(IMAGE_REPO):$(VERSION) $(QUAY_REPO):$(VERSION)
-	@sudo docker push $(QUAY_REPO):latest
-	@sudo docker push $(QUAY_REPO):$(VERSION)
+	@sudo docker tag $(LOCAL_REPO):$(VERSION) $(IMAGE_REPO):latest
+	@sudo docker tag $(LOCAL_REPO):$(VERSION) $(IMAGE_REPO):$(VERSION)
+	@sudo docker push $(IMAGE_REPO):latest
+	@sudo docker push $(IMAGE_REPO):$(VERSION)


### PR DESCRIPTION
* Add `make image` and `make push` targets to use rootless buildah for regular development. Retain docker build for Travis CI