### PR TITLE
Added powerPC support at .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 sudo: required
+arch:
+  - amd64
+  - ppc64le
 services:
   - docker
 go:


### PR DESCRIPTION
Adding support to Power architecture by including "ppc64le" in the arch section of travis.yml.
Currently, we have the binary for Matchbox-v0.8.3 stored at our FTP server.
https://oplab9.parqtec.unicamp.br/pub/ppc64el/matchbox/