### PR TITLE
`contrib/k8s` not in the release images

### DIFF
--- a/scripts/dev/release-files
+++ b/scripts/dev/release-files
@@ -29,6 +29,10 @@ cp scripts/tls/openssl.conf $SCRIPTS/tls
 mkdir -p $CONTRIB/systemd
 cp -r contrib/systemd/* $CONTRIB/systemd
 
+# k8s manifests
+mkdir -p $CONTRIB/k8s
+cp -r contrib/k8s/* $CONTRIB/k8s
+
 # examples
 mkdir -p $DEST/examples
 cp -r examples/{cloud,groups,ignition,profiles,README.md} $DEST/examples


### PR DESCRIPTION
The docs suggest it is (https://matchbox.psdn.io/deployment/#kubernetes) but they aren't there. They're only in the git checkout. Which is fine, but for consistency.