### PR TITLE
Fix for Kubernetes

### DIFF
--- a/contrib/k8s/matchbox-deployment.yaml
+++ b/contrib/k8s/matchbox-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: matchbox
@@ -7,11 +7,15 @@ spec:
   strategy:
     rollingUpdate:
       maxUnavailable: 1
+  selector:
+      matchLabels:
+        app: matchbox
   template:
     metadata:
       labels:
         name: matchbox
         phase: prod
+        app: matchbox
     spec:
       containers:
         - name: matchbox

--- a/contrib/k8s/matchbox-deployment.yaml
+++ b/contrib/k8s/matchbox-deployment.yaml
@@ -9,13 +9,12 @@ spec:
       maxUnavailable: 1
   selector:
       matchLabels:
-        app: matchbox
+        name: matchbox
   template:
     metadata:
       labels:
         name: matchbox
         phase: prod
-        app: matchbox
     spec:
       containers:
         - name: matchbox

--- a/contrib/k8s/matchbox-ingress.yaml
+++ b/contrib/k8s/matchbox-ingress.yaml
@@ -15,7 +15,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: matchbox
+  name: matchbox-rpc
   annotations:
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
 spec:

--- a/contrib/k8s/matchbox-ingress.yaml
+++ b/contrib/k8s/matchbox-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: matchbox
@@ -12,7 +12,7 @@ spec:
               serviceName: matchbox
               servicePort: 8080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: matchbox-rpc


### PR DESCRIPTION
Two minor fixes to allow Kubernetes deployments to work:

* Move the deploy to the app/v1 api version ([removed from Kubernetes 1.16 onward](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) - the app/v1 has been supported since Kubernetes 1.9)
* Modify the RPC ingress name so that is does not conflict with the primary matchbox ingress.