### PR TITLE
Fix simple-install to work with terraform 12

### DIFF
--- a/examples/terraform/simple-install/groups.tf
+++ b/examples/terraform/simple-install/groups.tf
@@ -4,7 +4,7 @@ resource "matchbox_group" "default" {
   profile = "${matchbox_profile.coreos-install.name}"
 
   # no selector means all machines can be matched
-  metadata {
+  metadata = {
     ignition_endpoint  = "${var.matchbox_http_endpoint}/ignition"
     ssh_authorized_key = "${var.ssh_authorized_key}"
   }
@@ -15,11 +15,11 @@ resource "matchbox_group" "node1" {
   name    = "node1"
   profile = "${matchbox_profile.simple.name}"
 
-  selector {
+  selector = {
     os = "installed"
   }
 
-  metadata {
+  metadata = {
     ssh_authorized_key = "${var.ssh_authorized_key}"
   }
 }


### PR DESCRIPTION
With terraform v0.12.13, this gives the following errors
```
Error: Unsupported block type

  on groups.tf line 18, in resource "matchbox_group" "node1":
  18:   selector {

Blocks of type "selector" are not expected here. Did you mean to define
argument "selector"? If so, use the equals sign to assign it a value.
```