### PR TITLE
Fix dnsmasq container image build

### DIFF
--- a/contrib/dnsmasq/get-tftp-files
+++ b/contrib/dnsmasq/get-tftp-files
@@ -11,6 +11,3 @@ fi
 curl -s -o $DEST/undionly.kpxe http://boot.ipxe.org/undionly.kpxe
 cp $DEST/undionly.kpxe $DEST/undionly.kpxe.0
 curl -s -o $DEST/ipxe.efi http://boot.ipxe.org/ipxe.efi
-
-# Any vaguely recent CoreOS grub.efi is fine
-curl -s -o $DEST/grub.efi https://stable.release.core-os.net/amd64-usr/1353.7.0/coreos_production_pxe_grub.efi


### PR DESCRIPTION
* Remove grub.efi from `quay.io/poseidon/dnsmasq` container image. Container Linux images are EOL and have been removed