### PR TITLE
Fix indentation in docs/index.md tutorials

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,8 @@ Matchbox can be installed from a binary or a container image.
 Start provisioning machines with Fedora CoreOS or Flatcar Linux.
 
 * [Terraform Usage](getting-started.md)
-  * Fedora CoreOS (live PXE or PXE install to disk)
-  * Flatcar Linux (live PXE or PXE install to disk)
+    * Fedora CoreOS (live PXE or PXE install to disk)
+    * Flatcar Linux (live PXE or PXE install to disk)
 * [Local QEMU/KVM](getting-started-docker.md)
     * Fedora CoreOS (live PXE or PXE install to disk)
     * Flatcar Linux (live PXE or PXE install to disk)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs==1.1.2
-mkdocs-material==6.0.2
+mkdocs-material==6.1.0
 pygments==2.6.1
 pymdown-extensions==7.1.0


### PR DESCRIPTION
* Update mkdocs-material from v6.0.2 to v6.1.0