### PR TITLE
Fix dirty version in recent container images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,3 @@
 bin/
-contrib/
-docs/
-examples/
-scripts/
 _output/
 


### PR DESCRIPTION
* Avoid dockerignore'ing source files, since this means a `COPY . /src` and git status (e.g. make) will detect the commit state as dirty/deletions