### PR TITLE
Update Fedora CoreOS examples for 33.20210117.3.2

### DIFF
--- a/docs/getting-started-docker.md
+++ b/docs/getting-started-docker.md
@@ -29,7 +29,7 @@ $ cd matchbox
 Download Fedora CoreOS or Flatcar Linux image assets to `examples/assets`.
 
 ```sh
-$ ./scripts/get-fedora-coreos stable 32.20200923.3.0 ./examples/assets
+$ ./scripts/get-fedora-coreos stable 33.20210117.3.2 ./examples/assets
 $ ./scripts/get-flatcar stable 2605.6.0 ./examples/assets
 ```
 

--- a/examples/ignition/fedora-coreos.ign
+++ b/examples/ignition/fedora-coreos.ign
@@ -7,7 +7,7 @@
       {
         "name": "core",
         "sshAuthorizedKeys": [
-          "ssh-rsa SET_PUBKEY_HERE"
+          "ssh-ed25519 SET_PUBKEY_HERE"
         ]
       }
     ]

--- a/examples/profiles/fedora-coreos-install.json
+++ b/examples/profiles/fedora-coreos-install.json
@@ -2,15 +2,15 @@
   "id": "fedora-coreos-install",
   "name": "Fedora CoreOS install to disk",
   "boot": {
-    "kernel": "/assets/fedora-coreos/fedora-coreos-32.20200923.3.0-live-kernel-x86_64",
+    "kernel": "/assets/fedora-coreos/fedora-coreos-33.20210117.3.2-live-kernel-x86_64",
     "initrd": [
-      "/assets/fedora-coreos/fedora-coreos-32.20200923.3.0-live-initramfs.x86_64.img",
-      "/assets/fedora-coreos/fedora-coreos-32.20200923.3.0-live-rootfs.x86_64.img"
+      "/assets/fedora-coreos/fedora-coreos-33.20210117.3.2-live-initramfs.x86_64.img",
+      "/assets/fedora-coreos/fedora-coreos-33.20210117.3.2-live-rootfs.x86_64.img"
     ],
     "args": [
       "coreos.inst.install_dev=/dev/sda",
       "coreos.inst.ignition_url=http://matchbox.example.com:8080/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
-      "coreos.inst.image_url=http://matchbox.example.com:8080/assets/fedora-coreos/fedora-coreos-32.20200923.3.0-metal.x86_64.raw.xz",
+      "coreos.inst.image_url=http://matchbox.example.com:8080/assets/fedora-coreos/fedora-coreos-33.20210117.3.2-metal.x86_64.raw.xz",
       "console=tty0",
       "console=ttyS0"
     ]

--- a/examples/profiles/fedora-coreos.json
+++ b/examples/profiles/fedora-coreos.json
@@ -2,10 +2,10 @@
   "id": "fedora-coreos",
   "name": "Fedora CoreOS",
   "boot": {
-    "kernel": "/assets/fedora-coreos/fedora-coreos-32.20200923.3.0-live-kernel-x86_64",
+    "kernel": "/assets/fedora-coreos/fedora-coreos-33.20210117.3.2-live-kernel-x86_64",
     "initrd": [
-      "/assets/fedora-coreos/fedora-coreos-32.20200923.3.0-live-initramfs.x86_64.img",
-      "/assets/fedora-coreos/fedora-coreos-32.20200923.3.0-live-rootfs.x86_64.img"
+      "/assets/fedora-coreos/fedora-coreos-33.20210117.3.2-live-initramfs.x86_64.img",
+      "/assets/fedora-coreos/fedora-coreos-33.20210117.3.2-live-rootfs.x86_64.img"
     ],
     "args": [
       "ignition.firstboot",

--- a/scripts/get-fedora-coreos
+++ b/scripts/get-fedora-coreos
@@ -5,7 +5,7 @@
 set -eou pipefail
 
 STREAM=${1:-"stable"}
-VERSION=${2:-"32.20200923.3.0"}
+VERSION=${2:-"33.20210117.3.2"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
 DEST=$DEST_DIR/fedora-coreos
 BASE_URL=https://builds.coreos.fedoraproject.org/prod/streams/$STREAM/builds/$VERSION/x86_64

--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Manage VM nodes which have a specific set of hardware attributes.
 
-VM_MEMORY=${VM_MEMORY:-2048}
+VM_MEMORY=${VM_MEMORY:-3048}
 VM_DISK=${VM_DISK:-10}
 
 if [ "$EUID" -ne 0 ]
@@ -49,10 +49,10 @@ NODE3_MAC=52:54:00:c3:61:77
 function create_docker {
   virt-install --name $NODE1_NAME --network=bridge:docker0,mac=$NODE1_MAC $COMMON_VIRT_OPTS --boot=hd,network
   virt-install --name $NODE2_NAME --network=bridge:docker0,mac=$NODE2_MAC $COMMON_VIRT_OPTS --boot=hd,network
-  virt-install --name $NODE3_NAME --network=bridge:docker0,mac=$NODE3_MAC $COMMON_VIRT_OPTS --boot=hd,network
+  # virt-install --name $NODE3_NAME --network=bridge:docker0,mac=$NODE3_MAC $COMMON_VIRT_OPTS --boot=hd,network
 }
 
-nodes=(node1 node2 node3)
+nodes=(node1 node2)
 
 function start {
   for node in ${nodes[@]}; do


### PR DESCRIPTION
* Update Fedora CoreOS live PXE and disk install examples to Fedora 33
* Increase libvirt VM memory from 2GB to 3GB to support live PXE example, which is mostly just for laptop examples/demos.
Reduce the VM count from 3 to 2 to compensate.
* Change `fedora-coreos.ign` to suggest using an ed25519 SSH key since Fedora CoreOS 33 disables RSA SHA1 (256 is still ok
but most people won't know which they have)