### PR TITLE
Improvement : Matchbox learns --files-dir

### DIFF
--- a/cmd/matchbox/main.go
+++ b/cmd/matchbox/main.go
@@ -29,6 +29,7 @@ func main() {
 		rpcAddress   string
 		dataPath     string
 		assetsPath   string
+        filesDir     string
 		logLevel     string
 		grpcCAFile   string
 		grpcCertFile string
@@ -44,6 +45,9 @@ func main() {
 	flag.StringVar(&flags.rpcAddress, "rpc-address", "", "RPC listen address")
 	flag.StringVar(&flags.dataPath, "data-path", "/var/lib/matchbox", "Path to data directory")
 	flag.StringVar(&flags.assetsPath, "assets-path", "/var/lib/matchbox/assets", "Path to static assets")
+
+    // From ct: local files dir
+    flag.StringVar(&flags.filesDir, "files-dir", "/var/lib/matchbox/files", "Directory to read local files from")
 
 	// Log levels https://github.com/sirupsen/logrus/blob/master/logrus.go#L36
 	flag.StringVar(&flags.logLevel, "log-level", "info", "Set the logging level")


### PR DESCRIPTION
Hello,

I have noticed container-linux-config-transpiler (ct) [supports including local files](https://github.com/coreos/container-linux-config-transpiler/blob/e4d5be564a0bda8197080222ebcf0a184143061c/doc/configuration.md) in the configuration, for example :
```
storage:
  files:
    - filesystem: "root"
      path: "/etc/test"
      contents:
        local: test
```

However, with matchbox, it would yield this error : the `ct` library/exec complains about a missing opt-arg.

```
time="2021-08-13T13:44:43Z" level=error msg="error converting Container Linux config: error at line 185, column 16\nlocal files require setting the --files-dir flag to the directory that contains the file"
```

Therefore my PR. I hardly have any knowledge in Go and I have been inspiring myself from the [clc code base](https://github.com/coreos/container-linux-config-transpiler/blob/e4d5be564a0bda8197080222ebcf0a184143061c/internal/main.go#L35)

Please, let me know what you think about it. Is this flag support desirable?

Regards,
