### PR TITLE
Allow passing alternative architecture for assets download

### DIFF
--- a/scripts/get-fedora-coreos
+++ b/scripts/get-fedora-coreos
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 # USAGE: ./scripts/get-fedora-coreos
-# USAGE: ./scripts/get-fedora-coreos stream version dest
+# USAGE: ./scripts/get-fedora-coreos stream version dest arch
 #
 set -eou pipefail
 
 STREAM=${1:-"stable"}
 VERSION=${2:-"33.20210117.3.2"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
-DEST=$DEST_DIR/fedora-coreos
-BASE_URL=https://builds.coreos.fedoraproject.org/prod/streams/$STREAM/builds/$VERSION/x86_64
+ARCH=${4:-"x86_64"}
+DEST=$DEST_DIR/fedora-coreos/$ARCH
+BASE_URL=https://builds.coreos.fedoraproject.org/prod/streams/$STREAM/builds/$VERSION/$ARCH
 
 # check stream/version exist based on the header response
-if ! curl -s -I $BASE_URL/fedora-coreos-$VERSION-metal.x86_64.raw.xz | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]' ; then
-  echo "Stream or Version not found"
+if ! curl -s -I $BASE_URL/fedora-coreos-$VERSION-metal.$ARCH.raw.xz | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]'; then
+  echo "Stream, Version or Architecture not found"
   exit 1
 fi
 
@@ -21,23 +22,22 @@ if [ ! -d "$DEST" ]; then
   mkdir -p $DEST
 fi
 
-echo "Downloading Fedora CoreOS $STREAM $VERSION images to $DEST"
+echo "Downloading Fedora CoreOS $STREAM $VERSION $ARCH images to $DEST"
 
 # PXE kernel
-echo "fedora-coreos-$VERSION-live-kernel-x86_64"
-curl -# $BASE_URL/fedora-coreos-$VERSION-live-kernel-x86_64 -o $DEST/fedora-coreos-$VERSION-live-kernel-x86_64
+echo "fedora-coreos-$VERSION-live-kernel-$ARCH"
+curl -# $BASE_URL/fedora-coreos-$VERSION-live-kernel-$ARCH -o $DEST/fedora-coreos-$VERSION-live-kernel-$ARCH
 
 # PXE initrd
-echo "fedora-coreos-$VERSION-live-initramfs.x86_64.img"
-curl -# $BASE_URL/fedora-coreos-$VERSION-live-initramfs.x86_64.img -o $DEST/fedora-coreos-$VERSION-live-initramfs.x86_64.img
+echo "fedora-coreos-$VERSION-live-initramfs.$ARCH.img"
+curl -# $BASE_URL/fedora-coreos-$VERSION-live-initramfs.$ARCH.img -o $DEST/fedora-coreos-$VERSION-live-initramfs.$ARCH.img
 
 # rootfs
-echo "fedora-coreos-$VERSION-live-rootfs.x86_64.img"
-curl -# $BASE_URL/fedora-coreos-$VERSION-live-rootfs.x86_64.img -o $DEST/fedora-coreos-$VERSION-live-rootfs.x86_64.img
+echo "fedora-coreos-$VERSION-live-rootfs.$ARCH.img"
+curl -# $BASE_URL/fedora-coreos-$VERSION-live-rootfs.$ARCH.img -o $DEST/fedora-coreos-$VERSION-live-rootfs.$ARCH.img
 
 # Install image
-echo "fedora-coreos-$VERSION-metal.x86_64.raw.xz"
-curl -# $BASE_URL/fedora-coreos-$VERSION-metal.x86_64.raw.xz -o $DEST/fedora-coreos-$VERSION-metal.x86_64.raw.xz
-echo "fedora-coreos-$VERSION-metal.x86_64.raw.xz.sig"
-curl -# $BASE_URL/fedora-coreos-$VERSION-metal.x86_64.raw.xz.sig -o $DEST/fedora-coreos-$VERSION-metal.x86_64.raw.xz.sig
-
+echo "fedora-coreos-$VERSION-metal.$ARCH.raw.xz"
+curl -# $BASE_URL/fedora-coreos-$VERSION-metal.$ARCH.raw.xz -o $DEST/fedora-coreos-$VERSION-metal.$ARCH.raw.xz
+echo "fedora-coreos-$VERSION-metal.$ARCH.raw.xz.sig"
+curl -# $BASE_URL/fedora-coreos-$VERSION-metal.$ARCH.raw.xz.sig -o $DEST/fedora-coreos-$VERSION-metal.$ARCH.raw.xz.sig

--- a/scripts/get-flatcar
+++ b/scripts/get-flatcar
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # USAGE: ./scripts/get-flatcar
-# USAGE: ./scripts/get-flatcar channel version dest
+# USAGE: ./scripts/get-flatcar channel version dest arch
 #
 # ENV VARS:
 # - OEM_ID - specify OEM image id to download, alongside the default one
@@ -11,13 +11,14 @@ GPG=${GPG:-/usr/bin/gpg}
 CHANNEL=${1:-"stable"}
 VERSION=${2:-"current"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
+ARCH=${4:-"amd64"}
 OEM_ID=${OEM_ID:-""}
-DEST=$DEST_DIR/flatcar/$VERSION
-BASE_URL=https://$CHANNEL.release.flatcar-linux.net/amd64-usr/$VERSION
+DEST=$DEST_DIR/flatcar/$ARCH/$VERSION
+BASE_URL=https://$CHANNEL.release.flatcar-linux.net/$ARCH-usr/$VERSION
 
 # check channel/version exist based on the header response
 if ! curl -s -I "${BASE_URL}/flatcar_production_pxe.vmlinuz" | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]'; then
-  echo "Channel or Version not found"
+  echo "Channel, Version or Architecture not found"
   exit 1
 fi
 
@@ -36,7 +37,7 @@ if [[ -n "${OEM_ID}" ]]; then
   fi
 fi
 
-echo "Downloading Flatcar Linux $CHANNEL $VERSION images and sigs to $DEST"
+echo "Downloading Flatcar Linux $CHANNEL $VERSION $ARCH images and sigs to $DEST"
 
 echo "Flatcar Linux Image Signing Key"
 curl -# https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc -o "${DEST}/Flatcar_Image_Signing_Key.asc"


### PR DESCRIPTION
The scripts can download assets for ARM too.
Tested with:

- `./scripts/get-fedora-coreos stable 35.20220131.3.0 . aarch64`
- `./scripts/get-flatcar "" "" . arm64`