### PR TITLE
Update iPXE example to match the FCOS iPXE documentation

### DIFF
--- a/examples/terraform/fedora-coreos-install/profiles.tf
+++ b/examples/terraform/fedora-coreos-install/profiles.tf
@@ -3,10 +3,11 @@ resource "matchbox_profile" "fedora-coreos-install" {
   name   = "worker"
   kernel = "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-kernel-x86_64"
   initrd = [
-    "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img"
+    "--name main https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img"
   ]
 
   args = [
+    "initrd=main",
     "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
     "coreos.inst.install_dev=/dev/sda",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",


### PR DESCRIPTION

This PR updates the examples to match the FCOS iPXE [docs](https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/#_installing_from_ipxe). Without these changes, the server will fail to boot with this error:

```
/dev/root can't open blockdev
```
