### PR TITLE
Add initrd=main karg to examples and update QEMU/KVM setup

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -226,7 +226,7 @@ matchbox
 If you enabled the gRPC API,
 
 ```sh
-$ openssl s_client -connect matchbox.example.com:8081 -CAfile /etc/matchbox/ca.crt -cert scripts/tls/client.crt -key scripts/tls/client.key
+$ openssl s_client -connect matchbox.example.com:8081 -CAfile scripts/tls/ca.crt -cert scripts/tls/client.crt -key scripts/tls/client.key
 CONNECTED(00000003)
 depth=1 CN = fake-ca
 verify return:1

--- a/docs/getting-started-docker.md
+++ b/docs/getting-started-docker.md
@@ -82,11 +82,16 @@ Create QEMU/KVM VMs which have known hardware attributes. The nodes will be atta
 $ sudo ./scripts/libvirt create
 ```
 
-You can connect to the serial console of any node (ctrl+] to exit). If you provisioned nodes with an SSH key, you can SSH after bring-up.
+If you provisioned nodes with an SSH key, you can SSH after bring-up.
 
 ```sh
-$ sudo virsh console node1
 $ ssh core@node1.example.com
+```
+
+If you set a `console=ttyS0` kernel arg, you can connect to the serial console of any node (ctrl+] to exit).
+
+```
+$ sudo virsh console node1
 ```
 
 You can also use `virt-manager` to watch the console.

--- a/examples/ignition/fedora-coreos.ign
+++ b/examples/ignition/fedora-coreos.ign
@@ -1,6 +1,6 @@
 {
   "ignition": {
-    "version": "3.1.0"
+    "version": "3.3.0"
   },
   "passwd": {
     "users": [

--- a/examples/ignition/fedora-coreos.yaml
+++ b/examples/ignition/fedora-coreos.yaml
@@ -1,8 +1,8 @@
 variant: fcos
-version: 1.1.0
+version: 1.4.0
 passwd:
   users:
     - name: core
       ssh_authorized_keys:
-        - ssh-rsa SET_PUBKEY_HERE
+        - ssh-ed25519 SET_PUBKEY_HERE
 

--- a/examples/profiles/fedora-coreos-install.json
+++ b/examples/profiles/fedora-coreos-install.json
@@ -4,14 +4,13 @@
   "boot": {
     "kernel": "/assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-kernel-x86_64",
     "initrd": [
-      "/assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img"
+      "--name main /assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img"
     ],
     "args": [
+      "initrd=main",
       "coreos.live.rootfs_url=http://matchbox.example.com:8080/assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img",
-      "coreos.inst.install_dev=/dev/sda",
-      "coreos.inst.ignition_url=http://matchbox.example.com:8080/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
-      "console=tty0",
-      "console=ttyS0"
+      "coreos.inst.install_dev=/dev/vda",
+      "coreos.inst.ignition_url=http://matchbox.example.com:8080/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}"
     ]
   },
   "ignition_id": "fedora-coreos.ign"

--- a/examples/profiles/fedora-coreos.json
+++ b/examples/profiles/fedora-coreos.json
@@ -4,15 +4,14 @@
   "boot": {
     "kernel": "/assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-kernel-x86_64",
     "initrd": [
-      "/assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img"
+      "--name main /assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img"
     ],
     "args": [
+      "initrd=main",
       "coreos.live.rootfs_url=http://matchbox.example.com:8080/assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img",
       "ignition.firstboot",
       "ignition.platform.id=metal",
-      "ignition.config.url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
-      "console=tty0",
-      "console=ttyS0"
+      "ignition.config.url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}"
     ]
   },
   "ignition_id": "fedora-coreos.ign"

--- a/examples/terraform/fedora-coreos-install/fcc/fedora-coreos.yaml
+++ b/examples/terraform/fedora-coreos-install/fcc/fedora-coreos.yaml
@@ -1,5 +1,5 @@
 variant: fcos
-version: 1.1.0
+version: 1.4.0
 passwd:
   users:
     - name: core

--- a/examples/terraform/fedora-coreos-install/profiles.tf
+++ b/examples/terraform/fedora-coreos-install/profiles.tf
@@ -11,23 +11,14 @@ resource "matchbox_profile" "fedora-coreos-install" {
     "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
     "coreos.inst.install_dev=/dev/sda",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
-    "console=tty0",
-    "console=ttyS0",
   ]
 
-  raw_ignition = data.ct_config.worker-ignition.rendered
+  raw_ignition = data.ct_config.worker.rendered
 }
 
-data "ct_config" "worker-ignition" {
-  content = data.template_file.worker-config.rendered
-  strict  = true
-}
-
-data "template_file" "worker-config" {
-  template = file("fcc/fedora-coreos.yaml")
-  vars = {
+data "ct_config" "worker" {
+  content = templatefile("fcc/fedora-coreos.yaml", {
     ssh_authorized_key = var.ssh_authorized_key
-  }
+  })
+  strict = true
 }
-
-

--- a/examples/terraform/fedora-coreos-install/provider.tf
+++ b/examples/terraform/fedora-coreos-install/provider.tf
@@ -10,11 +10,11 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.6.1"
+      version = "0.10.0"
     }
     matchbox = {
       source  = "poseidon/matchbox"
-      version = "0.4.1"
+      version = "0.5.0"
     }
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,17 +55,3 @@ Create QEMU/KVM VMs which are configured to boot from the network. The `scripts/
         shutdown    shutdown the QEMU/KVM nodes
         poweroff    poweroff the QEMU/KVM nodes
         destroy     destroy the QEMU/KVM nodes
-
-## k8s-certgen
-
-Generate TLS certificates needed for a multi-node Kubernetes cluster. See the [examples](../examples/README.md#assets).
-
-    $ ./scripts/tls/k8s-certgen -h
-    Usage: k8s-certgen
-    Options:
-      -d DEST     Destination for generated files (default: .examples/assets/tls)
-      -s SERVER   Reachable Server IP for kubeconfig (e.g. node1.example.com)
-      -m MASTERS  Controller Node Names/Addresses in SAN format (e.g. IP.1=10.3.0.1,DNS.1=node1.example.com)
-      -w WORKERS  Worker Node Names/Addresses in SAN format (e.g. DNS.1=node2.example.com,DNS.2=node3.example.com)
-      -h          Show help
-

--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -35,7 +35,7 @@ function usage {
   echo -e "\tdestroy\t\tdestroy the QEMU/KVM nodes"
 }
 
-COMMON_VIRT_OPTS="--memory=${VM_MEMORY} --vcpus=1 --disk pool=default,size=${VM_DISK} --os-type=linux --os-variant=generic --noautoconsole --events on_poweroff=preserve"
+COMMON_VIRT_OPTS="--memory=${VM_MEMORY} --vcpus=1 --disk pool=default,size=${VM_DISK} --os-variant=fedora-coreos-stable --noautoconsole"
 
 NODE1_NAME=node1
 NODE1_MAC=52:54:00:a1:9c:ae

--- a/scripts/tls/cert-gen
+++ b/scripts/tls/cert-gen
@@ -6,7 +6,7 @@ rm -f ca.key ca.crt server.key server.csr server.crt client.key client.csr clien
 rm -rf certs crl newcerts
 
 if [ -z $SAN ]
-  then echo "Set SAN with a DNS or IP for matchbox (e.g. export SAN=DNS.1:matchbox.example.com,IP.1:192.168.1.42)."
+  then echo "Set SAN with a DNS or IP for matchbox (e.g. export SAN=DNS.1:matchbox.example.com,IP.1:172.17.0.2)."
   exit 1
 fi
 


### PR DESCRIPTION
* Add initrd=main karg directive for UEFI (ignored by BIOS)
* Update Butane config version to v1.4.0 (generates Ignition v3.3.0) in `fedora-coreos` and `fedora-coreos-install` examples
* Update virt-install flag --os-variant
* Removed virt-install deprecated flag --os-type
* Remove virt-install QEMU/KVM event preserve since it apparently wasn't implemented anyway and QEMU/KVM now warns about it
* Remove serial consol kernel argument from examples, but still mention it in docs

Rel:
* https://github.com/coreos/fedora-coreos-docs/pull/282
* https://www.spinics.net/linux/fedora/libvir/msg222078.html