### PR TITLE
Fix GitHub Actions unit tests workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,6 @@
 name: test
 on:
   push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
 jobs:
   build:
     name: go


### PR DESCRIPTION
* Default branch was renamed from master to main
* Internal build and publishing workflows were unaffected, the GitHub Action is just for public contribution vetting