### PR TITLE
Update Flatcar Linux examples and use Ignition

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -248,7 +248,7 @@ Download a recent Fedora CoreOS or Flatcar Linux release.
 
 ```
 $ ./scripts/get-fedora-coreos stable 36.20220618.3.1 .
-$ ./scripts/get-flatcar stable 2605.6.0 .
+$ ./scripts/get-flatcar stable 3227.2.0 .
 ```
 
 Move the images to `/var/lib/matchbox/assets`,
@@ -260,7 +260,7 @@ Move the images to `/var/lib/matchbox/assets`,
 ├── fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img
 
 /var/lib/matchbox/assets/flatcar/
-└── 2605.6.0
+└── 3227.2.0
     ├── Flatcar_Image_Signing_Key.asc
     ├── flatcar_production_image.bin.bz2
     ├── flatcar_production_image.bin.bz2.sig

--- a/docs/getting-started-docker.md
+++ b/docs/getting-started-docker.md
@@ -30,7 +30,7 @@ Download Fedora CoreOS or Flatcar Linux image assets to `examples/assets`.
 
 ```sh
 $ ./scripts/get-fedora-coreos stable 36.20220618.3.1 ./examples/assets
-$ ./scripts/get-flatcar stable 2605.6.0 ./examples/assets
+$ ./scripts/get-flatcar stable 3227.2.0 ./examples/assets
 ```
 
 For development convenience, add `/etc/hosts` entries for nodes so they may be referenced by name.

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,36 +26,37 @@ These examples mount raw Matchbox objects into a Matchbox server's `/var/lib/mat
 | flatcar       | Flatcar Linux live PXE       | RAM | [docs](https://docs.flatcar-linux.org/os/booting-with-ipxe/) |
 | flatcar-install | Flatcar Linux install      | Disk | [docs](https://docs.flatcar-linux.org/os/booting-with-ipxe/) |
 
-### Customization
+### SSH Access
 
-For Fedora CoreOS, add an SSH authorized key to Fedora CoreOS Config (`ignition/fedora-coreos.yaml`) and regenerate the Ignition Config.
+For Fedora CoreOS, add an SSH authorized key to the Butane Config (`ignition/fedora-coreos.yaml`) and regenerate the Ignition Config.
 
 ```yaml
 variant: fcos
-version: 1.1.0
+version: 1.4.0
 passwd:
   users:
     - name: core
       ssh_authorized_keys:
-        - ssh-rsa pub-key-goes-here
+        - ssh-ed25519 SET_PUBKEY_HERE
 ```
 
 ```
 podman run -i --rm quay.io/coreos/fcct:release --pretty --strict < fedora-coreos.yaml > fedora-coreos.ign
 ```
 
-For Flatcar Linux, add a Matchbox variable to a Group (`groups/flatcar-install/flatcar.json`) to set the SSH authorized key (or directly update the Container Linux Config).
+For Flatcar Linux, add an SSH authorized key to the Butane config (`ignition/flatcar.yaml` or `ignition/flatcar-install.yaml`) and regenerate the Ignition Config.
 
-```json
-{
-  "id": "stage-1",
-  "name": "Flatcar Linux",
-  "profile": "flatcar",
-  "selector": {
-    "os": "installed"
-  },
-  "metadata": {
-    "ssh_authorized_keys": ["ssh-rsa pub-key-goes-here"]
-  }
-}
+```yaml
+variant: flatcar
+version: 1.0.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - ssh-ed25519 SET_PUBKEY_HERE
+```
+
+```
+podman run -i --rm quay.io/coreos/fcct:release --pretty --strict < flatcar.yaml > flatcar.ign
+podman run -i --rm quay.io/coreos/fcct:release --pretty --strict < flatcar-install.yaml > flatcar-install.ign
 ```

--- a/examples/groups/flatcar-install/flatcar.json
+++ b/examples/groups/flatcar-install/flatcar.json
@@ -5,6 +5,5 @@
   "selector": {
     "os": "installed"
   },
-  "metadata": {
-  }
+  "metadata": {}
 }

--- a/examples/groups/flatcar-install/install.json
+++ b/examples/groups/flatcar-install/install.json
@@ -2,10 +2,5 @@
   "id": "stage-0",
   "name": "Flatcar Linux install",
   "profile": "flatcar-install",
-  "metadata": {
-    "os_channel": "stable",
-    "os_version": "2605.6.0",
-    "ignition_endpoint": "http://matchbox.example.com:8080/ignition",
-    "baseurl": "http://matchbox.example.com:8080/assets/flatcar"
-  }
+  "metadata": {}
 }

--- a/examples/ignition/flatcar-install.ign
+++ b/examples/ignition/flatcar-install.ign
@@ -1,0 +1,36 @@
+{
+  "ignition": {
+    "version": "3.3.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "ssh-ed25519 SET_PUBKEY_HERE"
+        ]
+      }
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/opt/installer",
+        "contents": {
+          "compression": "gzip",
+          "source": "data:;base64,H4sIAAAAAAAC/4SOsU4DMRBEe3/FEmrbx1EQRUIU/AMVzdrecEZrb+TdnC5/T3GhoaF8mhnNe3yIqfaYUBfwtLl8HQzeD7Jxg6cJvD9jZTgsZpdTjA0tL0m2QBu2C1PI0k7H6TjF+tWrVelvoq+1qyEzlQN4gd8kfKt0d2a0jMPfO/DpAHyBWGiNa8Gd30ENE9NOH/A8zy9hDtPOCf61QVUyjfezfVb/mFwLrVgaKJkxOb2pUcvGMCiJmPsJAAD//1GtasgbAQAA"
+        },
+        "mode": 320
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "contents": "[Unit]\nRequires=network-online.target\nAfter=network-online.target\n[Service]\nType=simple\nExecStart=/opt/installer\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "installer.service"
+      }
+    ]
+  }
+}

--- a/examples/ignition/flatcar-install.yaml
+++ b/examples/ignition/flatcar-install.yaml
@@ -1,8 +1,10 @@
 ---
+variant: flatcar
+version: 1.0.0
 systemd:
   units:
     - name: installer.service
-      enable: true
+      enabled: true
       contents: |
         [Unit]
         Requires=network-online.target
@@ -15,28 +17,22 @@ systemd:
 storage:
   files:
     - path: /opt/installer
-      filesystem: root
       mode: 0500
       contents:
         inline: |
           #!/bin/bash -ex
-          curl --retry 10 --fail "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
+          curl --retry 10 --fail "http://matchbox.example.com:8080/ignition?os=installed" -o ignition.json
           flatcar-install \
-            -d /dev/sda \
-            -C {{.os_channel}} \
-            -V {{.os_version}} \
-            {{- if index . "baseurl"}}-b {{.baseurl}} \{{end}}
+            -d /dev/vda \
+            -C stable \
+            -V 3227.2.0 \
+            -b http://matchbox.example.com:8080/assets/flatcar \
             -i ignition.json
           udevadm settle
           systemctl reboot
 
-{{ if index . "ssh_authorized_keys" }}
 passwd:
   users:
     - name: core
       ssh_authorized_keys:
-        {{ range $element := .ssh_authorized_keys }}
-        - {{$element}}
-        {{end}}
-{{end}}
-
+        - ssh-ed25519 SET_PUBKEY_HERE

--- a/examples/ignition/flatcar.ign
+++ b/examples/ignition/flatcar.ign
@@ -1,0 +1,15 @@
+{
+  "ignition": {
+    "version": "3.3.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "ssh-ed25519 SET_PUBKEY_HERE"
+        ]
+      }
+    ]
+  }
+}

--- a/examples/ignition/flatcar.yaml
+++ b/examples/ignition/flatcar.yaml
@@ -1,10 +1,7 @@
----
-{{ if index . "ssh_authorized_keys" }}
+variant: flatcar
+version: 1.0.0
 passwd:
   users:
     - name: core
       ssh_authorized_keys:
-        {{ range $element := .ssh_authorized_keys }}
-        - {{$element}}
-        {{end}}
-{{end}}
+        - ssh-ed25519 SET_PUBKEY_HERE

--- a/examples/profiles/flatcar-install.json
+++ b/examples/profiles/flatcar-install.json
@@ -2,18 +2,16 @@
   "id": "flatcar-install",
   "name": "Flatcar Linux install to disk",
   "boot": {
-    "kernel": "/assets/flatcar/2605.6.0/flatcar_production_pxe.vmlinuz",
+    "kernel": "/assets/flatcar/3227.2.0/flatcar_production_pxe.vmlinuz",
     "initrd": [
-      "/assets/flatcar/2605.6.0/flatcar_production_pxe_image.cpio.gz"
+      "/assets/flatcar/3227.2.0/flatcar_production_pxe_image.cpio.gz"
     ],
     "args": [
       "initrd=flatcar_production_pxe_image.cpio.gz",
       "flatcar.config.url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "flatcar.first_boot=yes",
-      "console=tty0",
-      "console=ttyS0",
       "flatcar.autologin"
     ]
   },
-  "ignition_id": "flatcar-install.yaml"
+  "ignition_id": "flatcar-install.ign"
 }

--- a/examples/profiles/flatcar.json
+++ b/examples/profiles/flatcar.json
@@ -2,18 +2,16 @@
   "id": "flatcar",
   "name": "Flatcar Linux",
   "boot": {
-    "kernel": "/assets/flatcar/2605.6.0/flatcar_production_pxe.vmlinuz",
+    "kernel": "/assets/flatcar/3227.2.0/flatcar_production_pxe.vmlinuz",
     "initrd": [
-      "/assets/flatcar/2605.6.0/flatcar_production_pxe_image.cpio.gz"
+      "/assets/flatcar/3227.2.0/flatcar_production_pxe_image.cpio.gz"
     ],
     "args": [
       "initrd=flatcar_production_pxe_image.cpio.gz",
       "flatcar.config.url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "flatcar.first_boot=yes",
-      "console=tty0",
-      "console=ttyS0",
       "flatcar.autologin"
     ]
   },
-  "ignition_id": "flatcar.yaml"
+  "ignition_id": "flatcar.ign"
 }

--- a/examples/terraform/fedora-coreos-install/profiles.tf
+++ b/examples/terraform/fedora-coreos-install/profiles.tf
@@ -1,15 +1,15 @@
 // Fedora CoreOS profile
 resource "matchbox_profile" "fedora-coreos-install" {
   name   = "worker"
-  kernel = "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-kernel-x86_64"
+  kernel = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-kernel-x86_64"
   initrd = [
-    "--name main https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img"
+    "--name main /assets/fedora-coreos/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img"
   ]
 
   args = [
     "initrd=main",
-    "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
-    "coreos.inst.install_dev=/dev/sda",
+    "coreos.live.rootfs_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
+    "coreos.inst.install_dev=/dev/vda",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
   ]
 

--- a/examples/terraform/fedora-coreos-install/provider.tf
+++ b/examples/terraform/fedora-coreos-install/provider.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/ct"
-      version = "0.10.0"
+      version = "0.11.0"
     }
     matchbox = {
       source  = "poseidon/matchbox"

--- a/examples/terraform/flatcar-install/butane/flatcar-install.yaml
+++ b/examples/terraform/flatcar-install/butane/flatcar-install.yaml
@@ -1,8 +1,10 @@
 ---
+variant: flatcar
+version: 1.0.0
 systemd:
   units:
     - name: installer.service
-      enable: true
+      enabled: true
       contents: |
         [Unit]
         Requires=network-online.target
@@ -15,17 +17,14 @@ systemd:
 storage:
   files:
     - path: /opt/installer
-      filesystem: root
       mode: 0500
       contents:
         inline: |
           #!/bin/bash -ex
-          curl --retry 10 "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
+          curl --retry 10 "${matchbox_http_endpoint}/ignition?os=installed" -o ignition.json
           flatcar-install \
-            -d /dev/sda \
-            -C stable \
-            -V current \
-            {{- if index . "baseurl"}}-b {{.baseurl}} \{{end}}
+            -d /dev/vda \
+            -b ${matchbox_http_endpoint}/assets/flatcar \
             -i ignition.json
           udevadm settle
           systemctl reboot
@@ -33,4 +32,4 @@ passwd:
   users:
     - name: core
       ssh_authorized_keys:
-        - {{.ssh_authorized_key}}
+        - ${ssh_authorized_key}

--- a/examples/terraform/flatcar-install/butane/flatcar.yaml
+++ b/examples/terraform/flatcar-install/butane/flatcar.yaml
@@ -1,6 +1,8 @@
 ---
+variant: flatcar
+version: 1.0.0
 passwd:
   users:
     - name: core
       ssh_authorized_keys:
-        - {{.ssh_authorized_key}}
+        - ${ssh_authorized_key}

--- a/examples/terraform/flatcar-install/groups.tf
+++ b/examples/terraform/flatcar-install/groups.tf
@@ -2,24 +2,14 @@
 resource "matchbox_group" "default" {
   name    = "default"
   profile = matchbox_profile.flatcar-install.name
-
-  # no selector means all machines can be matched
-  metadata = {
-    ignition_endpoint  = "${var.matchbox_http_endpoint}/ignition"
-    ssh_authorized_key = var.ssh_authorized_key
-  }
 }
 
-// Match machines which have CoreOS Container Linux installed
-resource "matchbox_group" "node1" {
-  name    = "node1"
+// Match install stage Flatcar Linux machines
+resource "matchbox_group" "stage-1" {
+  name    = "worker"
   profile = matchbox_profile.worker.name
 
   selector = {
     os = "installed"
-  }
-
-  metadata = {
-    ssh_authorized_key = var.ssh_authorized_key
   }
 }

--- a/examples/terraform/flatcar-install/profiles.tf
+++ b/examples/terraform/flatcar-install/profiles.tf
@@ -1,24 +1,38 @@
 // Create a flatcar-install profile
 resource "matchbox_profile" "flatcar-install" {
   name   = "flatcar-install"
-  kernel = "http://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz"
+  kernel = "/assets/flatcar/3227.2.0/flatcar_production_pxe.vmlinuz"
   initrd = [
-    "http://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz",
+    "/assets/flatcar/3227.2.0/flatcar_production_pxe_image.cpio.gz",
   ]
 
   args = [
     "initrd=flatcar_production_pxe_image.cpio.gz",
     "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "flatcar.first_boot=yes",
-    "console=tty0",
-    "console=ttyS0",
   ]
 
-  container_linux_config = file("./clc/flatcar-install.yaml")
+  raw_ignition = data.ct_config.install.rendered
 }
+
+data "ct_config" "install" {
+  content = templatefile("butane/flatcar-install.yaml", {
+    matchbox_http_endpoint = var.matchbox_http_endpoint
+    ssh_authorized_key     = var.ssh_authorized_key
+  })
+  strict = true
+}
+
 
 // Profile to set an SSH authorized key on first boot from disk
 resource "matchbox_profile" "worker" {
-  name                   = "worker"
-  container_linux_config = file("./clc/flatcar.yaml")
+  name         = "worker"
+  raw_ignition = data.ct_config.worker.rendered
+}
+
+data "ct_config" "worker" {
+  content = templatefile("butane/flatcar.yaml", {
+    ssh_authorized_key = var.ssh_authorized_key
+  })
+  strict = true
 }

--- a/examples/terraform/flatcar-install/provider.tf
+++ b/examples/terraform/flatcar-install/provider.tf
@@ -8,9 +8,13 @@ provider "matchbox" {
 
 terraform {
   required_providers {
+    ct = {
+      source  = "poseidon/ct"
+      version = "0.11.0"
+    }
     matchbox = {
       source  = "poseidon/matchbox"
-      version = "0.4.1"
+      version = "0.5.0"
     }
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,7 +31,7 @@ This will create:
 
 ```
 examples/assets/flatcar/
-└── 2605.6.0
+└── 3227.2.0
     ├── Flatcar_Image_Signing_Key.asc
     ├── flatcar_production_image.bin.bz2
     ├── flatcar_production_image.bin.bz2.sig


### PR DESCRIPTION
* Flatcar Linux OS now supports Ignition v2.13+ which means it can accept Ignition v3.x spec's, like Fedora CoreOS. Matchbox supports this by serving Ignition documents directly
*Discontinue using Matchbox's Container Linux Config features in favor of its Ignition features
* Users of the poseidon/matchbox Terraform provider can pass a `matchbox_profile` `raw_ignition` contents with the desired Ignition v3.3 spec
* Users of the poseidon/ct Terraform provider can write Butane Config YAML, perform templating, and render an Ignition document using either the fcos or the flatcar variant

Rel: https://github.com/poseidon/terraform-provider-ct/releases/tag/v0.11.0