### PR TITLE
Add v0.9.1 release notes and update docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,22 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.9.1
+
+* Add dependabot Go module update automation ([#833](https://github.com/poseidon/matchbox/pull/833))
 * Build multi-arch container images (amd64, arm64) ([#823](https://github.com/poseidon/matchbox/pull/823))
+* Update Go version (v1.18.4) and alpine base image (v3.16.1)
+* Move `dnsmasq` container image to its own [repo](https://github.com/poseidon/dnsmasq) ([#840](https://github.com/poseidon/matchbox/pull/840))
+* Deprecate rendering Container Linux Configs
+  * Please migrate to serving CoreOS Ignition directly
+  * Use tools like [poseidon/ct](https://github.com/poseidon/terraform-provider-ct) or [butane](https://coreos.github.io/butane/getting-started/) to validate and convert a Butane Config (`focs` or `flatcar`) to Ignition (for Matchbox to serve)
+
+### Docs/Examples
+
+* Migrate docs website to GitHub Pages ([#976](https://github.com/poseidon/matchbox/pull/976))
+* Update Fedora CoreOS images and configuration ([#972](https://github.com/poseidon/matchbox/pull/972))
+* Update Fedora CoreOS initrd karg for UEFI ([#978](https://github.com/poseidon/matchbox/pull/978))
+* Update Flatcar Linux examples to use Ignition v3.3.0 ([#980](https://github.com/poseidon/matchbox/pull/980))
 
 ## v0.9.0
 

--- a/contrib/k8s/deployment.yaml
+++ b/contrib/k8s/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: matchbox
-          image: quay.io/poseidon/matchbox:v0.9.0
+          image: quay.io/poseidon/matchbox:v0.9.1
           env:
             - name: MATCHBOX_ADDRESS
               value: "0.0.0.0:8080"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,23 +17,23 @@ Choose one of the supported installation options:
 Download the latest Matchbox [release](https://github.com/poseidon/matchbox/releases).
 
 ```sh
-$ wget https://github.com/poseidon/matchbox/releases/download/v0.9.0/matchbox-v0.9.0-linux-amd64.tar.gz
-$ wget https://github.com/poseidon/matchbox/releases/download/v0.9.0/matchbox-v0.9.0-linux-amd64.tar.gz.asc
+$ wget https://github.com/poseidon/matchbox/releases/download/v0.9.1/matchbox-v0.9.1-linux-amd64.tar.gz
+$ wget https://github.com/poseidon/matchbox/releases/download/v0.9.1/matchbox-v0.9.1-linux-amd64.tar.gz.asc
 ```
 
 Verify the release has been signed by Dalton Hubble's GPG [Key](https://keyserver.ubuntu.com/pks/lookup?search=0x8F515AD1602065C8&op=vindex)'s signing subkey.
 
 ```sh
 $ gpg --keyserver keyserver.ubuntu.com --recv-key 2E3D92BF07D9DDCCB3BAE4A48F515AD1602065C8
-$ gpg --verify matchbox-v0.9.0-linux-amd64.tar.gz.asc matchbox-v0.9.0-linux-amd64.tar.gz
+$ gpg --verify matchbox-v0.9.1-linux-amd64.tar.gz.asc matchbox-v0.9.1-linux-amd64.tar.gz
 gpg: Good signature from "Dalton Hubble <dghubble@gmail.com>"
 ```
 
 Untar the release.
 
 ```sh
-$ tar xzvf matchbox-v0.9.0-linux-amd64.tar.gz
-$ cd matchbox-v0.9.0-linux-amd64
+$ tar xzvf matchbox-v0.9.1-linux-amd64.tar.gz
+$ cd matchbox-v0.9.1-linux-amd64
 ```
 
 ## Install
@@ -110,14 +110,14 @@ Run the container image with Podman,
 
 ```
 mkdir -p /var/lib/matchbox/assets
-podman run --net=host --rm -v /var/lib/matchbox:/var/lib/matchbox:Z -v /etc/matchbox:/etc/matchbox:Z,ro quay.io/poseidon/matchbox:v0.9.0 -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+podman run --net=host --rm -v /var/lib/matchbox:/var/lib/matchbox:Z -v /etc/matchbox:/etc/matchbox:Z,ro quay.io/poseidon/matchbox:v0.9.1 -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 ```
 
 Or with Docker,
 
 ```
 mkdir -p /var/lib/matchbox/assets
-sudo docker run --net=host --rm -v /var/lib/matchbox:/var/lib/matchbox:Z -v /etc/matchbox:/etc/matchbox:Z,ro quay.io/poseidon/matchbox:v0.9.0 -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+sudo docker run --net=host --rm -v /var/lib/matchbox:/var/lib/matchbox:Z -v /etc/matchbox:/etc/matchbox:Z,ro quay.io/poseidon/matchbox:v0.9.1 -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 ```
 
 Create machine profiles, groups, or Ignition configs by adding files to `/var/lib/matchbox`.

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -8,7 +8,7 @@ This guide covers releasing new versions of matchbox.
 Create a release commit which updates old version references.
 
 ```sh
-$ export VERSION=v0.9.0
+$ export VERSION=v0.9.1
 ```
 
 ## Tag
@@ -44,7 +44,7 @@ $ make release
 Verify the reported version.
 
 ```
-./_output/matchbox-v0.9.0-linux-amd64/matchbox -version
+./_output/matchbox-v0.9.1-linux-amd64/matchbox -version
 ```
 
 ## Signing


### PR DESCRIPTION
* Deprecate rendering Container Linux Configs
* Use tools like [poseidon/ct](https://github.com/poseidon/terraform-provider-ct) or [butane](https://coreos.github.io/butane/getting-started/) to validate and convert a Butane Config (`focs` or `flatcar`) to Ignition (for Matchbox to serve)
* Please migrate to serving CoreOS Ignition directly, the Container Linux related HTTP and gRPC endpoints will be removed in future