### PR TITLE
Update Fedora CoreOS examples to stable 36.20220906.3.2

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -247,7 +247,7 @@ Matchbox can serve OS images in development or lab environments to reduce bandwi
 Download a recent Fedora CoreOS or Flatcar Linux release.
 
 ```
-$ ./scripts/get-fedora-coreos stable 36.20220618.3.1 .
+$ ./scripts/get-fedora-coreos stable 36.20220906.3.2 .
 $ ./scripts/get-flatcar stable 3227.2.0 .
 ```
 
@@ -255,9 +255,9 @@ Move the images to `/var/lib/matchbox/assets`,
 
 ```
 /var/lib/matchbox/assets/fedora-coreos/
-├── fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img
-├── fedora-coreos-36.20220618.3.1-live-kernel-x86_64
-├── fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img
+├── fedora-coreos-36.20220906.3.2-live-initramfs.x86_64.img
+├── fedora-coreos-36.20220906.3.2-live-kernel-x86_64
+├── fedora-coreos-36.20220906.3.2-live-rootfs.x86_64.img
 
 /var/lib/matchbox/assets/flatcar/
 └── 3227.2.0

--- a/docs/getting-started-docker.md
+++ b/docs/getting-started-docker.md
@@ -29,7 +29,7 @@ $ cd matchbox
 Download Fedora CoreOS or Flatcar Linux image assets to `examples/assets`.
 
 ```sh
-$ ./scripts/get-fedora-coreos stable 36.20220618.3.1 ./examples/assets
+$ ./scripts/get-fedora-coreos stable 36.20220906.3.2 ./examples/assets
 $ ./scripts/get-flatcar stable 3227.2.0 ./examples/assets
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -144,7 +144,7 @@ cp terraform.tfvars.example terraform.tfvars
 ```tf
 matchbox_http_endpoint = "http://matchbox.example.com:8080"
 matchbox_rpc_endpoint  = "matchbox.example.com:8081"
-os_version             = "36.20220618.3.1"
+os_version             = "36.20220906.3.2"
 ssh_authorized_key     = "YOUR_SSH_KEY"
 ```
 

--- a/examples/profiles/fedora-coreos-install.json
+++ b/examples/profiles/fedora-coreos-install.json
@@ -2,13 +2,13 @@
   "id": "fedora-coreos-install",
   "name": "Fedora CoreOS install to disk",
   "boot": {
-    "kernel": "/assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-kernel-x86_64",
+    "kernel": "/assets/fedora-coreos/fedora-coreos-36.20220906.3.2-live-kernel-x86_64",
     "initrd": [
-      "--name main /assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img"
+      "--name main /assets/fedora-coreos/fedora-coreos-36.20220906.3.2-live-initramfs.x86_64.img"
     ],
     "args": [
       "initrd=main",
-      "coreos.live.rootfs_url=http://matchbox.example.com:8080/assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img",
+      "coreos.live.rootfs_url=http://matchbox.example.com:8080/assets/fedora-coreos/fedora-coreos-36.20220906.3.2-live-rootfs.x86_64.img",
       "coreos.inst.install_dev=/dev/vda",
       "coreos.inst.ignition_url=http://matchbox.example.com:8080/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}"
     ]

--- a/examples/profiles/fedora-coreos.json
+++ b/examples/profiles/fedora-coreos.json
@@ -2,13 +2,13 @@
   "id": "fedora-coreos",
   "name": "Fedora CoreOS",
   "boot": {
-    "kernel": "/assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-kernel-x86_64",
+    "kernel": "/assets/fedora-coreos/fedora-coreos-36.20220906.3.2-live-kernel-x86_64",
     "initrd": [
-      "--name main /assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img"
+      "--name main /assets/fedora-coreos/fedora-coreos-36.20220906.3.2-live-initramfs.x86_64.img"
     ],
     "args": [
       "initrd=main",
-      "coreos.live.rootfs_url=http://matchbox.example.com:8080/assets/fedora-coreos/fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img",
+      "coreos.live.rootfs_url=http://matchbox.example.com:8080/assets/fedora-coreos/fedora-coreos-36.20220906.3.2-live-rootfs.x86_64.img",
       "ignition.firstboot",
       "ignition.platform.id=metal",
       "ignition.config.url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}"

--- a/examples/terraform/fedora-coreos-install/terraform.tfvars.example
+++ b/examples/terraform/fedora-coreos-install/terraform.tfvars.example
@@ -1,4 +1,4 @@
 matchbox_http_endpoint = "http://matchbox.example.com:8080"
 matchbox_rpc_endpoint = "matchbox.example.com:8081"
-os_version = "36.20220618.3.1"
+os_version = "36.20220906.3.2"
 ssh_authorized_key = "YOUR_SSH_KEY"

--- a/examples/terraform/fedora-coreos-install/variables.tf
+++ b/examples/terraform/fedora-coreos-install/variables.tf
@@ -16,7 +16,7 @@ variable "os_stream" {
 
 variable "os_version" {
   type        = string
-  description = "Fedora CoreOS version to PXE and install (e.g. 36.20220618.3.1)"
+  description = "Fedora CoreOS version to PXE and install (e.g. 36.20220906.3.2)"
 }
 
 variable "ssh_authorized_key" {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,9 +13,9 @@ This will create:
 
 ```
 examples/assets/fedora-coreos/
-├── fedora-coreos-36.20220618.3.1-live-initramfs.x86_64.img
-├── fedora-coreos-36.20220618.3.1-live-kernel-x86_64
-├── fedora-coreos-36.20220618.3.1-live-rootfs.x86_64.img
+├── fedora-coreos-36.20220906.3.2-live-initramfs.x86_64.img
+├── fedora-coreos-36.20220906.3.2-live-kernel-x86_64
+├── fedora-coreos-36.20220906.3.2-live-rootfs.x86_64.img
 ```
 
 ## get-flatcar

--- a/scripts/get-fedora-coreos
+++ b/scripts/get-fedora-coreos
@@ -5,7 +5,7 @@
 set -eou pipefail
 
 STREAM=${1:-"stable"}
-VERSION=${2:-"36.20220618.3.1"}
+VERSION=${2:-"36.20220906.3.2"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
 DEST=$DEST_DIR/fedora-coreos
 BASE_URL=https://builds.coreos.fedoraproject.org/prod/streams/$STREAM/builds/$VERSION/x86_64


### PR DESCRIPTION
* Pick up some recent bug fixes with root disks in QEMU setups