### PR TITLE
Fix notable Go standard library warnings and deprecations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,21 +1,39 @@
 module github.com/poseidon/matchbox
 
-go 1.16
+go 1.18
 
 require (
 	github.com/coreos/butane v0.15.0
 	github.com/coreos/coreos-cloudinit v1.14.0
 	github.com/coreos/ignition/v2 v2.14.0
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
-	github.com/coreos/yaml v0.0.0-20141224210557-6b16a5714269 // indirect
 	github.com/golang/protobuf v1.5.2
-	github.com/kr/pretty v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d
+	google.golang.org/grpc v1.49.0
+)
+
+require (
+	github.com/aws/aws-sdk-go v1.30.28 // indirect
+	github.com/clarketm/json v1.14.1 // indirect
+	github.com/coreos/go-json v0.0.0-20211020211907-c63f628265de // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // indirect
+	github.com/coreos/go-systemd/v22 v22.0.0 // indirect
+	github.com/coreos/vcontext v0.0.0-20220603180515-2076d8d16945 // indirect
+	github.com/coreos/yaml v0.0.0-20141224210557-6b16a5714269 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect
+	github.com/vincent-petithory/dataurl v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
-	google.golang.org/grpc v1.49.0
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -39,7 +39,6 @@ github.com/aws/aws-sdk-go v1.30.28/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZve
 github.com/beevik/etree v1.1.1-0.20200718192613-4a2f8b9d084c/go.mod h1:0yGO2rna3S9DkITDWHY1bMtcY4IJ4w+4S+EooZUR0bE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -48,11 +47,7 @@ github.com/clarketm/json v1.14.1/go.mod h1:ynr2LRfb0fQU34l07csRNBTcivjySLLiY1YzQ
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/coreos/butane v0.15.0 h1:PKN1tL5t4iGLrSiJ3gDpf/pPZMQ6JSeVNS811F3tmpM=
 github.com/coreos/butane v0.15.0/go.mod h1:5b/piru1RoNVuHCgtvmLTFXPRK2AOziSBt0mX7u6aYI=
 github.com/coreos/coreos-cloudinit v1.14.0 h1:3bQRJaie3QC8EovAVbxiimLQgdxM6DxP1vJfUCEEl9w=
@@ -83,7 +78,6 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
-github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -128,7 +122,6 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -254,8 +247,6 @@ golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d h1:LO7XpTYMwTqxjLcGWPijK3vRXg1aWdlNOVOHRq45d7c=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -296,13 +287,9 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200610111108-226ff32320da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -312,7 +299,6 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/matchbox/cli/generic_create.go
+++ b/matchbox/cli/generic_create.go
@@ -1,10 +1,11 @@
 package cli
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"context"
+
 	"github.com/spf13/cobra"
 
 	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
@@ -36,7 +37,7 @@ func runGenericPutCmd(cmd *cobra.Command, args []string) {
 	}
 
 	client := mustClientFromCmd(cmd)
-	config, err := ioutil.ReadFile(flagFilename)
+	config, err := os.ReadFile(flagFilename)
 	if err != nil {
 		exitWithError(ExitError, err)
 	}

--- a/matchbox/cli/group_create.go
+++ b/matchbox/cli/group_create.go
@@ -1,9 +1,9 @@
 package cli
 
 import (
-	"io/ioutil"
-
 	"context"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
@@ -49,7 +49,7 @@ func runGroupPutCmd(cmd *cobra.Command, args []string) {
 }
 
 func loadGroup(filename string) (*storagepb.Group, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/matchbox/cli/ignition_create.go
+++ b/matchbox/cli/ignition_create.go
@@ -1,10 +1,11 @@
 package cli
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"context"
+
 	"github.com/spf13/cobra"
 
 	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
@@ -36,7 +37,7 @@ func runIgnitionPutCmd(cmd *cobra.Command, args []string) {
 	}
 
 	client := mustClientFromCmd(cmd)
-	config, err := ioutil.ReadFile(flagFilename)
+	config, err := os.ReadFile(flagFilename)
 	if err != nil {
 		exitWithError(ExitError, err)
 	}

--- a/matchbox/cli/profile_create.go
+++ b/matchbox/cli/profile_create.go
@@ -1,9 +1,9 @@
 package cli
 
 import (
-	"io/ioutil"
-
 	"context"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	pb "github.com/poseidon/matchbox/matchbox/server/serverpb"
@@ -57,7 +57,7 @@ func validateArgs(cmd *cobra.Command, args []string) error {
 }
 
 func loadProfile(filename string) (*storagepb.Profile, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/matchbox/http/ipxe.go
+++ b/matchbox/http/ipxe.go
@@ -25,7 +25,7 @@ boot
 // client machine data and chainload to the ipxeHandler.
 func ipxeInspect() http.Handler {
 	fn := func(w http.ResponseWriter, req *http.Request) {
-		fmt.Fprintf(w, ipxeBootstrap)
+		fmt.Fprint(w, ipxeBootstrap)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/matchbox/http/metadata_test.go
+++ b/matchbox/http/metadata_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"context"
+
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
@@ -49,7 +50,7 @@ func TestMetadataHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	// convert response (random order) to map (tests compare in order)
 	assert.Equal(t, expectedLines, metadataToMap(w.Body.String()))
-	assert.Equal(t, plainContentType, w.HeaderMap.Get(contentType))
+	assert.Equal(t, plainContentType, w.Header().Get(contentType))
 }
 
 func TestMetadataHandler_MetadataEdgeCases(t *testing.T) {
@@ -75,7 +76,7 @@ func TestMetadataHandler_MetadataEdgeCases(t *testing.T) {
 		// - key/value pairs are newline separated
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), c.expected)
-		assert.Equal(t, plainContentType, w.HeaderMap.Get(contentType))
+		assert.Equal(t, plainContentType, w.Header().Get(contentType))
 	}
 }
 

--- a/matchbox/http/render_test.go
+++ b/matchbox/http/render_test.go
@@ -15,11 +15,11 @@ func TestRenderJSON(t *testing.T) {
 	srv := NewServer(&Config{Logger: logger})
 	w := httptest.NewRecorder()
 	data := map[string][]string{
-		"a": []string{"b", "c"},
+		"a": {"b", "c"},
 	}
 	srv.renderJSON(w, data)
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, jsonContentType, w.HeaderMap.Get(contentType))
+	assert.Equal(t, jsonContentType, w.Header().Get(contentType))
 	assert.Equal(t, `{"a":["b","c"]}`, w.Body.String())
 }
 

--- a/matchbox/http/test_fixtures.go
+++ b/matchbox/http/test_fixtures.go
@@ -11,16 +11,4 @@ var (
 		Id:         "g1h2i3j4",
 		IgnitionId: "butane.yaml",
 	}
-
-	testProfileGeneric = &storagepb.Profile{
-		Id:         "g1h2i3j4",
-		IgnitionId: "generic.tmpl",
-	}
-
-	testGroupWithMAC = &storagepb.Group{
-		Id:       "test-group",
-		Name:     "test group",
-		Profile:  "g1h2i3j4",
-		Selector: map[string]string{"mac": validMACStr},
-	}
 )

--- a/matchbox/sign/writer_test.go
+++ b/matchbox/sign/writer_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -30,7 +29,7 @@ func TestSignatureHandler(t *testing.T) {
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, expectedBody, w.Body.String())
-	assert.NotEqual(t, "application/json", w.HeaderMap.Get("Content-Type"))
+	assert.NotEqual(t, "application/json", w.Header().Get("Content-Type"))
 }
 
 func TestSignatureHandler_ErrorStatusCode(t *testing.T) {
@@ -75,7 +74,7 @@ func TestSignatureHandler_SignatureError(t *testing.T) {
 type upperSigner struct{}
 
 func (s *upperSigner) Sign(w io.Writer, message io.Reader) error {
-	b, err := ioutil.ReadAll(message)
+	b, err := io.ReadAll(message)
 	if err != nil {
 		return err
 	}

--- a/matchbox/storage/filestore_test.go
+++ b/matchbox/storage/filestore_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -244,7 +243,7 @@ func TestCloudGet(t *testing.T) {
 // for testing. Returns the directory tree root. The caller must remove the
 // temp directory when finished.
 func setup(fixedStore *fake.FixedStore) (root string, err error) {
-	root, err = ioutil.TempDir("", "data")
+	root, err = os.MkdirTemp("", "data")
 	if err != nil {
 		return "", err
 	}
@@ -264,7 +263,7 @@ func setup(fixedStore *fake.FixedStore) (root string, err error) {
 		if err != nil {
 			return root, err
 		}
-		err = ioutil.WriteFile(profileFile, []byte(data), defaultFileMode)
+		err = os.WriteFile(profileFile, []byte(data), defaultFileMode)
 		if err != nil {
 			return root, err
 		}
@@ -279,28 +278,28 @@ func setup(fixedStore *fake.FixedStore) (root string, err error) {
 		if err != nil {
 			return root, err
 		}
-		err = ioutil.WriteFile(groupFile, []byte(data), defaultFileMode)
+		err = os.WriteFile(groupFile, []byte(data), defaultFileMode)
 		if err != nil {
 			return root, err
 		}
 	}
 	for name, content := range fixedStore.IgnitionConfigs {
 		ignitionFile := filepath.Join(ignitionDir, name)
-		err = ioutil.WriteFile(ignitionFile, []byte(content), defaultFileMode)
+		err = os.WriteFile(ignitionFile, []byte(content), defaultFileMode)
 		if err != nil {
 			return root, err
 		}
 	}
 	for name, content := range fixedStore.GenericConfigs {
 		genericFile := filepath.Join(genericDir, name)
-		err = ioutil.WriteFile(genericFile, []byte(content), defaultFileMode)
+		err = os.WriteFile(genericFile, []byte(content), defaultFileMode)
 		if err != nil {
 			return root, err
 		}
 	}
 	for name, content := range fixedStore.CloudConfigs {
 		cloudConfigFile := filepath.Join(cloudDir, name)
-		err = ioutil.WriteFile(cloudConfigFile, []byte(content), defaultFileMode)
+		err = os.WriteFile(cloudConfigFile, []byte(content), defaultFileMode)
 		if err != nil {
 			return root, err
 		}

--- a/matchbox/storage/fs.go
+++ b/matchbox/storage/fs.go
@@ -2,7 +2,7 @@ package storage
 
 import (
 	"errors"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -28,17 +28,17 @@ func (d Dir) readFile(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 // readDir reads the directory named by the given path and returns a list of
 // sorted directory entries. Restricted to a specified directory tree.
-func (d Dir) readDir(dirname string) ([]os.FileInfo, error) {
+func (d Dir) readDir(dirname string) ([]fs.DirEntry, error) {
 	path, err := d.sanitize(dirname)
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadDir(path)
+	return os.ReadDir(path)
 }
 
 // writeFile writes the data as a file at given path, restricted to a specific
@@ -52,7 +52,7 @@ func (d Dir) writeFile(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), defaultDirectoryMode); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, data, defaultFileMode)
+	return os.WriteFile(path, data, defaultFileMode)
 }
 
 // deleteFile removes the file at the given path, restricted to a specific

--- a/matchbox/storage/fs_test.go
+++ b/matchbox/storage/fs_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,7 +20,7 @@ func TestDir(t *testing.T) {
 		{"d/e/ff", "d/e/ff"},
 		{"d/e/ff/../gg", "d/e/gg"},
 	}
-	tdir, err := ioutil.TempDir("", "matchbox")
+	tdir, err := os.MkdirTemp("", "matchbox")
 	assert.Nil(t, err)
 	defer os.RemoveAll(tdir)
 
@@ -29,7 +28,8 @@ func TestDir(t *testing.T) {
 	dir := Dir(tdir)
 	// write files rooted in the dir
 	for _, c := range cases {
-		dir.writeFile(c.path, []byte(c.expected))
+		err = dir.writeFile(c.path, []byte(c.expected))
+		assert.Nil(t, err)
 	}
 	// ensure expected files were created
 	for _, c := range cases {

--- a/matchbox/tlsutil/tlsutil.go
+++ b/matchbox/tlsutil/tlsutil.go
@@ -3,7 +3,7 @@ package tlsutil
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 )
 
 // NewCertPool creates x509 certPool with provided CA files.
@@ -11,7 +11,7 @@ func NewCertPool(CAFiles []string) (*x509.CertPool, error) {
 	certPool := x509.NewCertPool()
 
 	for _, CAFile := range CAFiles {
-		pemByte, err := ioutil.ReadFile(CAFile)
+		pemByte, err := os.ReadFile(CAFile)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* Replace ioutil methods with equivalent io and os methods
* Remove unneccesary types from slice literals
* Update the minimum Go version to v1.18