### PR TITLE
Configureable architecture for get-flatcar script

### DIFF
--- a/scripts/get-flatcar
+++ b/scripts/get-flatcar
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # USAGE: ./scripts/get-flatcar
-# USAGE: ./scripts/get-flatcar channel version dest
+# USAGE: ./scripts/get-flatcar channel version dest arch
 #
 # ENV VARS:
 # - OEM_ID - specify OEM image id to download, alongside the default one
@@ -11,9 +11,10 @@ GPG=${GPG:-/usr/bin/gpg}
 CHANNEL=${1:-"stable"}
 VERSION=${2:-"current"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
+ARCH=${4:-"amd64"}
 OEM_ID=${OEM_ID:-""}
 DEST=$DEST_DIR/flatcar/$VERSION
-BASE_URL=https://$CHANNEL.release.flatcar-linux.net/amd64-usr/$VERSION
+BASE_URL=https://$CHANNEL.release.flatcar-linux.net/${ARCH}-usr/$VERSION
 
 # check channel/version exist based on the header response
 if ! curl -s -I "${BASE_URL}/flatcar_production_pxe.vmlinuz" | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]'; then


### PR DESCRIPTION
This introduces a fourth parameter to the get-flatcar script which allows to select the architecture of the downloads. This allows to download files for arm64. The options for this parameter are 'amd64 and arm64. The default is unchanged 'amd64'.

Example:
./get-flatcar beta current ./lib/assets arm64