### PR TITLE
Remove gopkg.in/yaml.v2 from indirect version selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/aws/aws-sdk-go v1.30.28 // indirect
 	github.com/clarketm/json v1.17.1 // indirect
 	github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34 // indirect
-	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-semver v0.3.1-0.20220328174955-167f5da54033 // indirect
 	github.com/coreos/go-systemd/v22 v22.4.0 // indirect
 	github.com/coreos/vcontext v0.0.0-20220810162454-88bd546c634c // indirect
 	github.com/coreos/yaml v0.0.0-20141224210557-6b16a5714269 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34 h1:14qC8Go5ArRXeK4n
 github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34/go.mod h1:jdmhE6D2v5tisGyVw92x7/r3USTNm2VAkdRZ4ZydKQk=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.1-0.20220328174955-167f5da54033 h1:EFU0eBaol9U5CfTrmhCtr9Q1xv+mmwrDwF5yHSrMYyw=
+github.com/coreos/go-semver v0.3.1-0.20220328174955-167f5da54033/go.mod h1:5Y3UAMJpoC9iTP3pIpwQLVMpi9ZtX30wiA6ZThmZmFs=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.4.0 h1:y9YHcjnjynCd/DVbg5j9L/33jQM3MxJlbj/zWskzfGU=
 github.com/coreos/go-systemd/v22 v22.4.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=


### PR DESCRIPTION
* Update github.com/coreos/go-semver from v0.3.0 to 167f5da to prevent it using gopkg.in/yaml.v2 (CVE-2019-11254)

```
go mod why gopkg.in/yaml.v2
# gopkg.in/yaml.v2
(main module does not need package gopkg.in/yaml.v2)
```