### PR TITLE
Add opencontainer container image labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ RUN cd src && make build
 
 FROM docker.io/alpine:3.17.0
 LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
+LABEL org.opencontainers.image.title="Matchbox",
+LABEL org.opencontainers.image.source="https://github.com/poseidon/matchbox"
+LABEL org.opencontainers.image.documentation="https://matchbox.psdn.io"
+LABEL org.opencontainers.image.vendor="Poseidon Labs"
 COPY --from=builder /go/src/bin/matchbox /matchbox
 EXPOSE 8080
 ENTRYPOINT ["/matchbox"]


### PR DESCRIPTION
* Allow automation tools to find the repo source, changelogs, and other release information via container image labels