### PR TITLE
CPU architecture detection with iPXE

### DIFF
--- a/matchbox/http/ipxe.go
+++ b/matchbox/http/ipxe.go
@@ -10,7 +10,7 @@ import (
 )
 
 const ipxeBootstrap = `#!ipxe
-chain ipxe?uuid=${uuid}&mac=${mac:hexhyp}&domain=${domain}&hostname=${hostname}&serial=${serial}
+chain ipxe?uuid=${uuid}&mac=${mac:hexhyp}&domain=${domain}&hostname=${hostname}&serial=${serial}&arch=${buildarch:uristring}
 `
 
 var ipxeTemplate = template.Must(template.New("iPXE config").Parse(`#!ipxe


### PR DESCRIPTION
Some commands were added in the ipxeBootstrap to enable architecture detection based on the architecture the iPXE version used was built for. 
This is done through the use of an additional flag in the ipxeBootstrap string using the buildarch parameter.
