### PR TITLE
Prepare release notes for v0.10.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,18 +4,23 @@ Notable changes between releases.
 
 ## Latest
 
-* Upgrade Ignition from v0.35.0 (spec v2.x) to v2.14.0 (spec v3.x)
-* Parse Ignition and render forward to the current Ignition spec version
-  * Ignition is [forward](https://github.com/coreos/ignition/blob/main/config/v3_3/config.go#L61) compatible (a `v3.1` spec can be rendered as `v3.3` safely)
-* Recommend preparing Ignition externally (**action required**)
-  * Use Terraform with [poseidon/terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct)
-  * For a CLI, use Butane
+## v0.10.0
+
+* Remove support for Ignition v0.35.0 (Ignition spec v2.x)
 * Remove support for Container Linux Configs (**action required**)
+  * Container Linux Configs were a YAML format that rendered to Ignition (spec v2.x)
   * Flatcar Linux now supports Ignition v2 (spec v3.x)
   * Butane is a suitable YAML format that renders Ignition v2 (spec v3.x)
-* Add limited support for Matchbox rendering Butane configs
+* Upgrade Ignition from v0.35.0 (spec v2.x) to v2.14.0 (spec v3.x)
+* Update Go version (v1.20.2) and alpine base image (v3.17.3)
+* Add limited support for Matchbox rendering Butane configs ([#997](https://github.com/poseidon/matchbox/pull/997))
+* Recommend writing Butane via external tools (**action required**)
+  * For Terraform, use [poseidon/terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct)
+  * For a CLI, use [`butane`](https://github.com/coreos/butane)
+* Parse Ignition and render forward to Ignition v2 (spec v3.3)
+  * Ignition is [forward](https://github.com/coreos/ignition/blob/main/config/v3_3/config.go#L61) compatible (e.g. a `v3.1` spec can be rendered as `v3.3` safely)
 
-For those still templating Container Linux Configs, you may be able to convert to Butane by prepending:
+If you still template Container Linux Configs via Matchbox, [migrate](https://www.flatcar.org/docs/latest/provisioning/config-transpiler/) to Butane by prepending:
 
 ```yaml
 variant: flatcar

--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,15 @@ _output/matchbox-%.tar.gz: bin/%/matchbox
 .PHONY: all build clean test release
 .SECONDARY: _output/matchbox-linux-amd64 _output/matchbox-darwin-amd64
 
+release-sign:
+	gpg2 --armor --detach-sign _output/matchbox-$(VERSION)-linux-amd64.tar.gz
+	gpg2 --armor --detach-sign _output/matchbox-$(VERSION)-linux-arm.tar.gz
+	gpg2 --armor --detach-sign _output/matchbox-$(VERSION)-linux-arm64.tar.gz
+	gpg2 --armor --detach-sign _output/matchbox-$(VERSION)-darwin-amd64.tar.gz
+
+release-verify: NAME=_output/matchbox
+release-verify:
+	gpg2 --verify $(NAME)-$(VERSION)-linux-amd64.tar.gz.asc $(NAME)-$(VERSION)-linux-amd64.tar.gz
+	gpg2 --verify $(NAME)-$(VERSION)-linux-arm.tar.gz.asc $(NAME)-$(VERSION)-linux-arm.tar.gz
+	gpg2 --verify $(NAME)-$(VERSION)-linux-arm64.tar.gz.asc $(NAME)-$(VERSION)-linux-arm64.tar.gz
+	gpg2 --verify $(NAME)-$(VERSION)-darwin-amd64.tar.gz.asc $(NAME)-$(VERSION)-darwin-amd64.tar.gz

--- a/contrib/k8s/deployment.yaml
+++ b/contrib/k8s/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: matchbox
-          image: quay.io/poseidon/matchbox:v0.9.1
+          image: quay.io/poseidon/matchbox:v0.10.0
           env:
             - name: MATCHBOX_ADDRESS
               value: "0.0.0.0:8080"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,23 +17,23 @@ Choose one of the supported installation options:
 Download the latest Matchbox [release](https://github.com/poseidon/matchbox/releases).
 
 ```sh
-$ wget https://github.com/poseidon/matchbox/releases/download/v0.9.1/matchbox-v0.9.1-linux-amd64.tar.gz
-$ wget https://github.com/poseidon/matchbox/releases/download/v0.9.1/matchbox-v0.9.1-linux-amd64.tar.gz.asc
+$ wget https://github.com/poseidon/matchbox/releases/download/v0.10.0/matchbox-v0.10.0-linux-amd64.tar.gz
+$ wget https://github.com/poseidon/matchbox/releases/download/v0.10.0/matchbox-v0.10.0-linux-amd64.tar.gz.asc
 ```
 
 Verify the release has been signed by Dalton Hubble's GPG [Key](https://keyserver.ubuntu.com/pks/lookup?search=0x8F515AD1602065C8&op=vindex)'s signing subkey.
 
 ```sh
 $ gpg --keyserver keyserver.ubuntu.com --recv-key 2E3D92BF07D9DDCCB3BAE4A48F515AD1602065C8
-$ gpg --verify matchbox-v0.9.1-linux-amd64.tar.gz.asc matchbox-v0.9.1-linux-amd64.tar.gz
+$ gpg --verify matchbox-v0.10.0-linux-amd64.tar.gz.asc matchbox-v0.10.0-linux-amd64.tar.gz
 gpg: Good signature from "Dalton Hubble <dghubble@gmail.com>"
 ```
 
 Untar the release.
 
 ```sh
-$ tar xzvf matchbox-v0.9.1-linux-amd64.tar.gz
-$ cd matchbox-v0.9.1-linux-amd64
+$ tar xzvf matchbox-v0.10.0-linux-amd64.tar.gz
+$ cd matchbox-v0.10.0-linux-amd64
 ```
 
 ## Install
@@ -110,14 +110,14 @@ Run the container image with Podman,
 
 ```
 mkdir -p /var/lib/matchbox/assets
-podman run --net=host --rm -v /var/lib/matchbox:/var/lib/matchbox:Z -v /etc/matchbox:/etc/matchbox:Z,ro quay.io/poseidon/matchbox:v0.9.1 -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+podman run --net=host --rm -v /var/lib/matchbox:/var/lib/matchbox:Z -v /etc/matchbox:/etc/matchbox:Z,ro quay.io/poseidon/matchbox:v0.10.0 -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 ```
 
 Or with Docker,
 
 ```
 mkdir -p /var/lib/matchbox/assets
-sudo docker run --net=host --rm -v /var/lib/matchbox:/var/lib/matchbox:Z -v /etc/matchbox:/etc/matchbox:Z,ro quay.io/poseidon/matchbox:v0.9.1 -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
+sudo docker run --net=host --rm -v /var/lib/matchbox:/var/lib/matchbox:Z -v /etc/matchbox:/etc/matchbox:Z,ro quay.io/poseidon/matchbox:v0.10.0 -address=0.0.0.0:8080 -rpc-address=0.0.0.0:8081 -log-level=debug
 ```
 
 Create machine profiles, groups, or Ignition configs by adding files to `/var/lib/matchbox`.

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -8,7 +8,7 @@ This guide covers releasing new versions of matchbox.
 Create a release commit which updates old version references.
 
 ```sh
-$ export VERSION=v0.9.1
+$ export VERSION=v0.10.0
 ```
 
 ## Tag
@@ -18,7 +18,7 @@ Tag, sign the release version, and push it to Github.
 ```sh
 $ git tag -s vX.Y.Z -m 'vX.Y.Z'
 $ git push origin --tags
-$ git push origin master
+$ git push origin main
 ```
 
 ## Images
@@ -44,7 +44,7 @@ $ make release
 Verify the reported version.
 
 ```
-./_output/matchbox-v0.9.1-linux-amd64/matchbox -version
+./_output/matchbox-v0.10.0-linux-amd64/matchbox -version
 ```
 
 ## Signing
@@ -52,20 +52,13 @@ Verify the reported version.
 Release tarballs are signed by Dalton Hubble's GPG [Key](/docs/deployment.md#download)
 
 ```sh
-cd _output
-gpg2 --armor --detach-sign matchbox-$VERSION-linux-amd64.tar.gz
-gpg2 --armor --detach-sign matchbox-$VERSION-darwin-amd64.tar.gz
-gpg2 --armor --detach-sign matchbox-$VERSION-linux-arm.tar.gz
-gpg2 --armor --detach-sign matchbox-$VERSION-linux-arm64.tar.gz
+make release-sign
 ```
 
 Verify the signatures.
 
 ```sh
-gpg2 --verify matchbox-$VERSION-linux-amd64.tar.gz.asc matchbox-$VERSION-linux-amd64.tar.gz
-gpg2 --verify matchbox-$VERSION-darwin-amd64.tar.gz.asc matchbox-$VERSION-darwin-amd64.tar.gz
-gpg2 --verify matchbox-$VERSION-linux-arm.tar.gz.asc matchbox-$VERSION-linux-arm.tar.gz
-gpg2 --verify matchbox-$VERSION-linux-arm64.tar.gz.asc matchbox-$VERSION-linux-arm64.tar.gz
+make release-verify
 ```
 
 ## Publish


### PR DESCRIPTION
* Emphasize that Container Linux Configs have been dropped and that Butane is the way forward to use modern Ignition v2
* Include some links to Flatcar Linux docs