### PR TITLE
examples: repair variable expansion for mac and uuid in examples

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ resource "matchbox_profile" "fedora-coreos-install" {
     "initrd=main",
     "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
     "coreos.inst.install_dev=/dev/sda",
-    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}"
+    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=${uuid}&mac=${mac:hexhyp}"
   ]
 
   raw_ignition = data.ct_config.worker.rendered

--- a/docs/ignition.md
+++ b/docs/ignition.md
@@ -101,7 +101,7 @@ resource "matchbox_profile" "fedora-coreos-install" {
     "initrd=main",
     "coreos.live.rootfs_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
     "coreos.inst.install_dev=/dev/vda",
-    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
   ]
 
   raw_ignition = data.ct_config.worker.rendered

--- a/examples/profiles/fedora-coreos-install.json
+++ b/examples/profiles/fedora-coreos-install.json
@@ -10,7 +10,7 @@
       "initrd=main",
       "coreos.live.rootfs_url=http://matchbox.example.com:8080/assets/fedora-coreos/fedora-coreos-36.20220906.3.2-live-rootfs.x86_64.img",
       "coreos.inst.install_dev=/dev/vda",
-      "coreos.inst.ignition_url=http://matchbox.example.com:8080/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}"
+      "coreos.inst.ignition_url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}"
     ]
   },
   "ignition_id": "fedora-coreos.ign"

--- a/examples/terraform/fedora-coreos-install/profiles.tf
+++ b/examples/terraform/fedora-coreos-install/profiles.tf
@@ -10,7 +10,7 @@ resource "matchbox_profile" "fedora-coreos-install" {
     "initrd=main",
     "coreos.live.rootfs_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
     "coreos.inst.install_dev=/dev/vda",
-    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
   ]
 
   raw_ignition = data.ct_config.worker.rendered

--- a/examples/terraform/flatcar-install/profiles.tf
+++ b/examples/terraform/flatcar-install/profiles.tf
@@ -8,7 +8,7 @@ resource "matchbox_profile" "flatcar-install" {
 
   args = [
     "initrd=flatcar_production_pxe_image.cpio.gz",
-    "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
     "flatcar.first_boot=yes",
   ]
 


### PR DESCRIPTION
* currently there is a duplicated $ in front of some of the variables used to render the ignition_url mac and uuid matches, leading to broken variable expansion and impossible matches
* remove duplicated $ to for all ignition_urls and update docs accordingly