### PR TITLE
Render Butane or raw Ignition to Ignition spec v3.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Notable changes between releases.
 
 ## Latest
 
+* Update butane from v0.17.0 to v0.18.0
+  * Add support for `fcos` [v1.5.0](https://coreos.github.io/butane/config-fcos-v1_5/) Butane Configs
+  * Add support for `flatcar` [v1.1.0](https://coreos.github.io/butane/config-flatcar-v1_1/) Butane Configs
+* Render Ignition as Ignition spec [v3.4.0](https://coreos.github.io/ignition/configuration-v3_4/)
+
 ## v0.10.0
 
 * Remove support for Ignition v0.35.0 (Ignition spec v2.x)

--- a/docs/ignition.md
+++ b/docs/ignition.md
@@ -54,7 +54,7 @@ Define a Butane config for Fedora CoreOS or Flatcar Linux:
 
 ```yaml
 variant: fcos
-version: 1.4.0
+version: 1.5.0
 passwd:
   users:
     - name: core
@@ -64,7 +64,7 @@ passwd:
 
 ```yaml
 variant: flatcar
-version: 1.0.0
+version: 1.1.0
 passwd:
   users:
     - name: core
@@ -137,7 +137,7 @@ Here is an example Butane config with Matchbox template elements. Template files
 
 ```yaml
 variant: flatcar
-version: 1.0.0
+version: 1.1.0
 storage:
   files:
     - path: /var/home/core/foo

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,7 +32,7 @@ For Fedora CoreOS, add an SSH authorized key to the Butane Config (`ignition/fed
 
 ```yaml
 variant: fcos
-version: 1.4.0
+version: 1.5.0
 passwd:
   users:
     - name: core
@@ -48,7 +48,7 @@ For Flatcar Linux, add an SSH authorized key to the Butane config (`ignition/fla
 
 ```yaml
 variant: flatcar
-version: 1.0.0
+version: 1.1.0
 passwd:
   users:
     - name: core

--- a/examples/ignition/fedora-coreos.yaml
+++ b/examples/ignition/fedora-coreos.yaml
@@ -1,5 +1,5 @@
 variant: fcos
-version: 1.4.0
+version: 1.5.0
 passwd:
   users:
     - name: core

--- a/examples/ignition/flatcar-install.yaml
+++ b/examples/ignition/flatcar-install.yaml
@@ -1,6 +1,6 @@
 ---
 variant: flatcar
-version: 1.0.0
+version: 1.1.0
 systemd:
   units:
     - name: installer.service

--- a/examples/ignition/flatcar.yaml
+++ b/examples/ignition/flatcar.yaml
@@ -1,5 +1,5 @@
 variant: flatcar
-version: 1.0.0
+version: 1.1.0
 passwd:
   users:
     - name: core

--- a/examples/terraform/fedora-coreos-install/fcc/fedora-coreos.yaml
+++ b/examples/terraform/fedora-coreos-install/fcc/fedora-coreos.yaml
@@ -1,5 +1,5 @@
 variant: fcos
-version: 1.4.0
+version: 1.5.0
 passwd:
   users:
     - name: core

--- a/examples/terraform/flatcar-install/butane/flatcar-install.yaml
+++ b/examples/terraform/flatcar-install/butane/flatcar-install.yaml
@@ -1,6 +1,6 @@
 ---
 variant: flatcar
-version: 1.0.0
+version: 1.1.0
 systemd:
   units:
     - name: installer.service

--- a/examples/terraform/flatcar-install/butane/flatcar.yaml
+++ b/examples/terraform/flatcar-install/butane/flatcar.yaml
@@ -1,6 +1,6 @@
 ---
 variant: flatcar
-version: 1.0.0
+version: 1.1.0
 passwd:
   users:
     - name: core

--- a/matchbox/http/ignition.go
+++ b/matchbox/http/ignition.go
@@ -7,7 +7,7 @@ import (
 
 	butane "github.com/coreos/butane/config"
 	"github.com/coreos/butane/config/common"
-	ignition "github.com/coreos/ignition/v2/config/v3_3"
+	ignition "github.com/coreos/ignition/v2/config/v3_4"
 	"github.com/sirupsen/logrus"
 
 	"github.com/poseidon/matchbox/matchbox/server"

--- a/matchbox/http/ignition_test.go
+++ b/matchbox/http/ignition_test.go
@@ -15,8 +15,8 @@ import (
 	fake "github.com/poseidon/matchbox/matchbox/storage/testfakes"
 )
 
-func TestIgnitionHandler_V33(t *testing.T) {
-	const content = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.3.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":false,"name":"docker.service"}]}}`
+func TestIgnitionHandler_v3_4(t *testing.T) {
+	const content = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.4.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":false,"name":"docker.service"}]}}`
 	profile := &storagepb.Profile{
 		Id:         fake.Group.Profile,
 		IgnitionId: "file.ign",
@@ -41,9 +41,9 @@ func TestIgnitionHandler_V33(t *testing.T) {
 	assert.Equal(t, content, w.Body.String())
 }
 
-func TestIgnitionHandler_V31(t *testing.T) {
+func TestIgnitionHandler_v3_1(t *testing.T) {
 	const ign31 = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.1.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":false,"name":"docker.service"}]}}`
-	const ign33 = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.3.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":false,"name":"docker.service"}]}}`
+	const ign34 = `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.4.0"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["key"]}]},"storage":{},"systemd":{"units":[{"enabled":false,"name":"docker.service"}]}}`
 	profile := &storagepb.Profile{
 		Id:         fake.Group.Profile,
 		IgnitionId: "file.ign",
@@ -70,7 +70,7 @@ func TestIgnitionHandler_V31(t *testing.T) {
 	// - serve Ignition JSON
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, jsonContentType, w.Header().Get(contentType))
-	assert.Equal(t, ign33, w.Body.String())
+	assert.Equal(t, ign34, w.Body.String())
 }
 
 func TestIgnitionHandler_MissingIgnition(t *testing.T) {
@@ -90,7 +90,7 @@ func TestIgnitionHandler_Butane(t *testing.T) {
 	// exercise templating features, not a realistic Butane template
 	butane := `
 variant: flatcar
-version: 1.0.0
+version: 1.1.0
 systemd:
   units:
     - name: {{.uuid}}.service
@@ -100,7 +100,7 @@ systemd:
       enabled: true
       contents: {{.request.raw_query}}
 `
-	expectedIgnition := `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.3.0"},"kernelArguments":{},"passwd":{},"storage":{},"systemd":{"units":[{"contents":"10.2.0.0/16","enabled":true,"name":"a1b2c3d4.service"},{"contents":"foo=some-param\u0026bar=b","enabled":true,"name":"some-param.service"}]}}`
+	expectedIgnition := `{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.4.0"},"kernelArguments":{},"passwd":{},"storage":{},"systemd":{"units":[{"contents":"10.2.0.0/16","enabled":true,"name":"a1b2c3d4.service"},{"contents":"foo=some-param\u0026bar=b","enabled":true,"name":"some-param.service"}]}}`
 
 	store := &fake.FixedStore{
 		Profiles: map[string]*storagepb.Profile{
@@ -142,7 +142,7 @@ func TestIgnitionHandler_MissingCtxProfile(t *testing.T) {
 func TestIgnitionHandler_MissingTemplateMetadata(t *testing.T) {
 	butane := `
 variant: flatcar
-version: 1.0.0
+version: 1.1.0
 systemd:
   units:
     - name: {{.missing_key}}


### PR DESCRIPTION
* Add support for fcos v1.5.0 Butane Configs
* Add support for flatcar v1.1.0 Butane Configs
* Render Butane or raw Ignition to Ignition spec v3.4.0 using Ignition's forward compatibility support

Rel:

* https://coreos.github.io/butane/config-fcos-v1_5/
* https://coreos.github.io/butane/config-flatcar-v1_1/
* https://coreos.github.io/ignition/configuration-v3_4/