### PR TITLE
Update raw Ignition examples to use Ignition spec v3.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,10 @@ Notable changes between releases.
 
 ## Latest
 
-* Update butane from v0.17.0 to v0.18.0
+* Update butane from v0.17.0 to v0.18.0 ([#1079](https://github.com/poseidon/matchbox/pull/1079))
   * Add support for `fcos` [v1.5.0](https://coreos.github.io/butane/config-fcos-v1_5/) Butane Configs
   * Add support for `flatcar` [v1.1.0](https://coreos.github.io/butane/config-flatcar-v1_1/) Butane Configs
-* Render Ignition as Ignition spec [v3.4.0](https://coreos.github.io/ignition/configuration-v3_4/)
+  * Render Ignition as Ignition spec [v3.4.0](https://coreos.github.io/ignition/configuration-v3_4/)
 
 ## v0.10.0
 

--- a/examples/ignition/fedora-coreos.ign
+++ b/examples/ignition/fedora-coreos.ign
@@ -1,6 +1,6 @@
 {
   "ignition": {
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "passwd": {
     "users": [

--- a/examples/ignition/flatcar-install.ign
+++ b/examples/ignition/flatcar-install.ign
@@ -1,6 +1,6 @@
 {
   "ignition": {
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "passwd": {
     "users": [

--- a/examples/ignition/flatcar.ign
+++ b/examples/ignition/flatcar.ign
@@ -1,6 +1,6 @@
 {
   "ignition": {
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "passwd": {
     "users": [

--- a/examples/profiles/fedora-coreos-install.json
+++ b/examples/profiles/fedora-coreos-install.json
@@ -10,7 +10,7 @@
       "initrd=main",
       "coreos.live.rootfs_url=http://matchbox.example.com:8080/assets/fedora-coreos/fedora-coreos-36.20220906.3.2-live-rootfs.x86_64.img",
       "coreos.inst.install_dev=/dev/vda",
-      "coreos.inst.ignition_url=http://matchbox.example.com:8080/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}"
+      "coreos.inst.ignition_url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}"
     ]
   },
   "ignition_id": "fedora-coreos.ign"


### PR DESCRIPTION
* Regenerate example Ignition using fcct v0.18.0 to produce Ignition spec v3.4.0 as a followup to https://github.com/poseidon/matchbox/pull/1079
* Fix one profile example where a double escape isn't needed