### PR TITLE
Migrate container image builds to GitHub Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,15 @@
+name: build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  go:
+    uses: poseidon/.github/.github/workflows/golang-library.yaml@main
+  multiarch:
+    uses: poseidon/fleetlock/.github/workflows/multiarch.yaml@main
+    secrets:
+      QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,0 @@
-name: test
-on:
-  push:
-jobs:
-  go:
-    uses: poseidon/.github/.github/workflows/golang-library.yaml@main

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,21 @@ image-%:
 	--arch $* --override-arch $* \
 	--format=docker .
 
+push: \
+	push-amd64
+	push-arm64
+
+push-%:
+	buildah tag $(LOCAL_REPO):$(VERSION)-$* $(IMAGE_REPO):$(VERSION)-$*
+	buildah push --format v2s2 $(IMAGE_REPO):$(VERSION)-$*
+
+manifest:
+	buildah manifest create $(IMAGE_REPO):$(VERSION)
+	buildah manifest add $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-amd64
+	buildah manifest add --variant v8 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-arm64
+	buildah manifest inspect $(IMAGE_REPO):$(VERSION)
+	buildah manifest push -f v2s2 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)
+
 protoc/%:
 	podman run --security-opt label=disable \
 		-u root \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # matchbox
 [![GoDoc](https://pkg.go.dev/badge/github.com/poseidon/matchbox.svg)](https://pkg.go.dev/github.com/poseidon/matchbox)
 [![Quay](https://img.shields.io/badge/container-quay-green)](https://quay.io/repository/poseidon/matchbox)
-[![Workflow](https://github.com/poseidon/matchbox/actions/workflows/test.yaml/badge.svg)](https://github.com/poseidon/matchbox/actions/workflows/test.yaml?query=branch%3Amain)
+[![Workflow](https://github.com/poseidon/matchbox/actions/workflows/build.yaml/badge.svg)](https://github.com/poseidon/matchbox/actions/workflows/build.yaml?query=branch%3Amain)
 ![Downloads](https://img.shields.io/github/downloads/poseidon/matchbox/total)
 [![Sponsors](https://img.shields.io/github/sponsors/poseidon?logo=github)](https://github.com/sponsors/poseidon)
 [![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@poseidon)


### PR DESCRIPTION
* Migrate from the internal Drone server using a GitHub Workflow to perform the multi-arch container image build
* Use self-hosted GitHub runners on ARM64 to perform the ARM64 build step faster that QEMU/KVM emulation
* Mandate approval for all workflow runs from outside contributors since the builds use push credentials and partially run internally