### PR TITLE
Add mkdocs-pages GitHub Workflow

### DIFF
--- a/.github/workflows/mkdocs-pages.yaml
+++ b/.github/workflows/mkdocs-pages.yaml
@@ -1,0 +1,26 @@
+name: mkdocs-pages
+on:
+  workflow_call:
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repo to GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Install Python
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      # Install PyPI packages
+      - name: Dependencies
+        run: pip install -r requirements.txt
+
+      # Push to GitHub Pages
+      - name: Push Docs
+        run: |
+          mkdocs gh-deploy --force

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,13 @@
+name: publish
+on:
+  push:
+    branches:
+      - release-docs
+jobs:
+  mkdocs:
+    name: mkdocs
+    uses: ./.github/workflows/mkdocs-pages.yaml
+    # Add content write for GitHub Pages
+    permissions:
+      contents: write
+


### PR DESCRIPTION
* Add a publish workflow that uses the mkdocs-pages re-usable GitHub Workflow when the `release-docs` branch is updated
* Build the docs site with mkdocs and publish to GitHub Pages