### PR TITLE
Adding Nix building configuration

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,9 @@
+{pkgs ? import <nixpkgs> {}}: let
+  lib = pkgs.lib;
+  matchbox = pkgs.buildGoModule {
+  name = "matchbox";
+  src = lib.cleanSource ../matchbox;
+  vendorHash = "sha256-sVC4xeQIcqAbKU4MOAtNicHcioYjdsleQwKWLstnjfk";
+};
+in matchbox
+


### PR DESCRIPTION
This PR adds `default.nix`. This allows users to use the Nix building system to create the binary.
`matchbox` is then added to the `nixstore`.

```console
$ git clone https://github.com/poseidon/matchbox/
$ cd matchbox
$ nix-build
this derivation will be built:
  /nix/store/96f9rm6xbbw8ggkd9v187h6s849y8lka-matchbox.drv
building '/nix/store/96f9rm6xbbw8ggkd9v187h6s849y8lka-matchbox.drv'...
unpacking sources
unpacking source archive /nix/store/a592kv07ff9yx9ly71nmwva591ky1www-source
source root is source
patching sources
updateAutotoolsGnuConfigScriptsPhase
configuring
building
Building subPackage ./cmd/bootcmd
Building subPackage ./cmd/matchbox
Building subPackage ./matchbox/cli
Building subPackage ./matchbox/client
Building subPackage ./matchbox/http
Building subPackage ./matchbox/rpc
Building subPackage ./matchbox/rpc/rpcpb
Building subPackage ./matchbox/server
Building subPackage ./matchbox/server/serverpb
Building subPackage ./matchbox/sign
Building subPackage ./matchbox/storage
Building subPackage ./matchbox/storage/storagepb
Building subPackage ./matchbox/storage/testfakes
Building subPackage ./matchbox/tlsutil
Building subPackage ./matchbox/version
running tests
ok      github.com/poseidon/matchbox/matchbox/client    0.005s
ok      github.com/poseidon/matchbox/matchbox/http      0.019s
ok      github.com/poseidon/matchbox/matchbox/rpc       0.005s
ok      github.com/poseidon/matchbox/matchbox/server    0.005s
ok      github.com/poseidon/matchbox/matchbox/sign      0.008s
ok      github.com/poseidon/matchbox/matchbox/storage   0.010s
ok      github.com/poseidon/matchbox/matchbox/storage/storagepb 0.005s
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/yxpjkjwfc5m37av6xbp179bxbfzn3n2w-matchbox
shrinking /nix/store/yxpjkjwfc5m37av6xbp179bxbfzn3n2w-matchbox/bin/matchbox
shrinking /nix/store/yxpjkjwfc5m37av6xbp179bxbfzn3n2w-matchbox/bin/bootcmd
checking for references to /build/ in /nix/store/yxpjkjwfc5m37av6xbp179bxbfzn3n2w-matchbox...
patching script interpreter paths in /nix/store/yxpjkjwfc5m37av6xbp179bxbfzn3n2w-matchbox
stripping (with command strip and flags -S -p) in  /nix/store/yxpjkjwfc5m37av6xbp179bxbfzn3n2w-matchbox/bin
/nix/store/yxpjkjwfc5m37av6xbp179bxbfzn3n2w-matchbox
$
```