### PR TITLE
Remove dependency on github.com/coreos/pkg

### DIFF
--- a/cmd/matchbox/flakgutil.go
+++ b/cmd/matchbox/flakgutil.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// SetFlagsFromEnv parses all registered flags in the given flagset,
+// and if they are not already set it attempts to set their values from
+// environment variables. Environment variables take the name of the flag but
+// are UPPERCASE, and any dashes are replaced by underscores. Environment
+// variables additionally are prefixed by the given string followed by
+// and underscore. For example, if prefix=PREFIX: some-flag => PREFIX_SOME_FLAG
+func SetFlagsFromEnv(fs *flag.FlagSet, prefix string) (err error) {
+	alreadySet := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) {
+		alreadySet[f.Name] = true
+	})
+	fs.VisitAll(func(f *flag.Flag) {
+		if !alreadySet[f.Name] {
+			key := prefix + "_" + strings.ToUpper(strings.Replace(f.Name, "-", "_", -1))
+			val := os.Getenv(key)
+			if val != "" {
+				if serr := fs.Set(f.Name, val); serr != nil {
+					err = fmt.Errorf("invalid value %q for %s: %v", val, key, serr)
+				}
+			}
+		}
+	})
+	return err
+}

--- a/cmd/matchbox/main.go
+++ b/cmd/matchbox/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/coreos/pkg/flagutil"
 	web "github.com/poseidon/matchbox/matchbox/http"
 	"github.com/poseidon/matchbox/matchbox/rpc"
 	"github.com/poseidon/matchbox/matchbox/server"
@@ -69,7 +68,7 @@ func main() {
 
 	// parse command-line and environment variable arguments
 	flag.Parse()
-	if err := flagutil.SetFlagsFromEnv(flag.CommandLine, "MATCHBOX"); err != nil {
+	if err := SetFlagsFromEnv(flag.CommandLine, "MATCHBOX"); err != nil {
 		log.Fatal(err.Error())
 	}
 	// restrict OpenPGP passphrase to pass via environment variable only

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/coreos/butane v0.20.0
 	github.com/coreos/coreos-cloudinit v1.14.0
 	github.com/coreos/ignition/v2 v2.18.0
-	github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf
 	github.com/golang/protobuf v1.5.4
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/ignition/v2 v2.18.0 h1:sPSGGsxaCuFMpKOMBQ71I9RIR20SIF4dWnoTomcPEYQ=
 github.com/coreos/ignition/v2 v2.18.0/go.mod h1:TURPHDqWUWTmej8c+CEMBENMU3N/Lt6GfreHJuoDMbA=
-github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf h1:GOPo6vn/vTN+3IwZBvXX0y5doJfSC7My0cdzelyOCsQ=
-github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/vcontext v0.0.0-20230201181013-d72178a18687 h1:uSmlDgJGbUB0bwQBcZomBTottKwEDF5fF8UjSwKSzWM=
 github.com/coreos/vcontext v0.0.0-20230201181013-d72178a18687/go.mod h1:Salmysdw7DAVuobBW/LwsKKgpyCPHUhjyJoMJD+ZJiI=
 github.com/coreos/yaml v0.0.0-20141224210557-6b16a5714269 h1:/1sjrpK5Mb6IwyFOKd+u7321tXfNAsj0Ci8CivZmSlo=


### PR DESCRIPTION
* Remove dependency on github.com/coreos/pkg because the module is no longer maintained and it doesn't follow the usual release conventions
* The last time flagutils was touched as 9 years ago by me. Bring the function into the matchbox repo