### PR TITLE
Add enforce workflow to wait for PR status checks

### DIFF
--- a/.github/workflows/mkdocs-pages.yaml
+++ b/.github/workflows/mkdocs-pages.yaml
@@ -12,7 +12,7 @@ jobs:
 
       # Install Python
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: 3.x
 

--- a/.github/workflows/summary.yaml
+++ b/.github/workflows/summary.yaml
@@ -1,0 +1,8 @@
+name: summary
+on:
+  pull_request:
+jobs:
+  enforce:
+    uses: ./.github/workflows/wait-for-status-checks.yaml
+    permissions:
+      checks: read

--- a/.github/workflows/wait-for-status-checks.yaml
+++ b/.github/workflows/wait-for-status-checks.yaml
@@ -1,0 +1,16 @@
+name: wait-for-status-checks
+on:
+  workflow_call:
+jobs:
+  status-checks:
+    runs-on: [self-hosted, Linux, X64]
+    permissions:
+      checks: read
+    steps:
+      - name: GitHub Checks
+        uses: poseidon/wait-for-status-checks@5fc55bcf5e80b8beab24f45ec6ed96b133d89e42 # v0.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # wait-for-status-checks ignores it's own check name, but it does
+          # not know the full name when used inside a reusable workflow
+          ignore: "enforce / status-checks"


### PR DESCRIPTION
* Add wait-for-status-checks reusable GitHub Workflow to wait for all status checks in a PR. Mark this as a required check so that GitHub auto-merge can be used

Rel: https://github.com/poseidon/wait-for-status-checks/