### PR TITLE
Remove fleet references from docs

### DIFF
--- a/docs/api-http.md
+++ b/docs/api-http.md
@@ -97,8 +97,6 @@ coreos:
   units:
     - name: etcd2.service
       command: start
-    - name: fleet.service
-      command: start
 ```
 
 ## Ignition Config

--- a/docs/cloud-config.md
+++ b/docs/cloud-config.md
@@ -30,8 +30,6 @@ coreos:
   units:
     - name: etcd2.service
       command: start
-    - name: fleet.service
-      command: start
 write_files:
   - path: "/home/core/welcome"
     owner: "core"

--- a/docs/machine-lifecycle.md
+++ b/docs/machine-lifecycle.md
@@ -8,7 +8,7 @@ Physical machines [network boot](network-booting.md) in an network boot environm
 
 Container Linux boots ("first boot" from disk) and runs Ignition to provision its disk with systemd units, files, keys, and more to become a cluster node. Systemd units may fetch metadata from a remote source if needed.
 
-Coordinated auto-updates are enabled. Systems like [fleet](https://coreos.com/docs/#fleet) or [Kubernetes](http://kubernetes.io/docs/) coordinate container services. IPMI, vendor utilities, or first-boot are used to re-provision machines into new roles.
+Coordinated auto-updates are enabled. Systems like [Kubernetes](http://kubernetes.io/docs/) coordinate container services. IPMI, vendor utilities, or first-boot are used to re-provision machines into new roles.
 
 ## Machine lifecycle
 

--- a/docs/matchbox.md
+++ b/docs/matchbox.md
@@ -95,7 +95,6 @@ Create a group definition with a `Profile` to be applied, selectors for matching
     "mac": "52:54:00:89:d8:10"
   },
   "metadata": {
-    "fleet_metadata": "role=etcd,name=node1",
     "etcd_name": "node1",
     "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380"
   }
@@ -109,7 +108,6 @@ Meanwhile, `/var/lib/matchbox/groups/proxy.json` acts as the default machine gro
   "name": "etcd-proxy",
   "profile": "etcd-proxy",
   "metadata": {
-    "fleet_metadata": "role=etcd-proxy",
     "etcd_initial_cluster": "node1=http://node1.example.com:2380,node2=http://node2.example.com:2380,node3=http://node3.example.com:2380"
   }
 }
@@ -146,7 +144,6 @@ Within Butane Config templates, Cloud-Config templates, or generic templates, yo
 {{.mac}}                # 52:54:00:89:d8:10 (normalized)
 # Metadata
 {{.etcd_name}}          # node1
-{{.fleet_metadata}}     # role=etcd,name=node1
 # Query
 {{.request.query.mac}}  # 52:54:00:89:d8:10 (normalized)
 {{.request.query.foo}}  # some-param


### PR DESCRIPTION
Fleet no longer seems to be used, and the docs link is broken.