### PR TITLE
Fix asset fetching scripts and complain earlier in case of failure

### DIFF
--- a/scripts/get-fedora-coreos
+++ b/scripts/get-fedora-coreos
@@ -25,12 +25,12 @@ echo "Downloading Fedora CoreOS $STREAM $VERSION images to $DEST"
 
 # PXE kernel
 echo "fedora-coreos-$VERSION-live-kernel-x86_64"
-curl -# $BASE_URL/fedora-coreos-$VERSION-live-kernel-x86_64 -o $DEST/fedora-coreos-$VERSION-live-kernel-x86_64
+curl -f# $BASE_URL/fedora-coreos-$VERSION-live-kernel-x86_64 -o $DEST/fedora-coreos-$VERSION-live-kernel-x86_64
 
 # PXE initrd
 echo "fedora-coreos-$VERSION-live-initramfs.x86_64.img"
-curl -# $BASE_URL/fedora-coreos-$VERSION-live-initramfs.x86_64.img -o $DEST/fedora-coreos-$VERSION-live-initramfs.x86_64.img
+curl -f# $BASE_URL/fedora-coreos-$VERSION-live-initramfs.x86_64.img -o $DEST/fedora-coreos-$VERSION-live-initramfs.x86_64.img
 
 # rootfs
 echo "fedora-coreos-$VERSION-live-rootfs.x86_64.img"
-curl -# $BASE_URL/fedora-coreos-$VERSION-live-rootfs.x86_64.img -o $DEST/fedora-coreos-$VERSION-live-rootfs.x86_64.img
+curl -f# $BASE_URL/fedora-coreos-$VERSION-live-rootfs.x86_64.img -o $DEST/fedora-coreos-$VERSION-live-rootfs.x86_64.img

--- a/scripts/get-flatcar
+++ b/scripts/get-flatcar
@@ -50,7 +50,7 @@ curl -f# "${BASE_URL}/version.txt" -o "${DEST}/version.txt"
 echo "flatcar_production_pxe.vmlinuz..."
 curl -f# "${BASE_URL}/flatcar_production_pxe.vmlinuz" -o "${DEST}/flatcar_production_pxe.vmlinuz"
 echo "flatcar_production_pxe.vmlinuz.sig"
-curl -f# "${BASE_URL}/flatcar_production_pxe.vmlinuz.sig" -o "${DEST}/flatcar_production_pxe.vmlinuz.sig"
+curl -f# "${BASE_URL}/flatcar_production_image.vmlinuz.sig" -o "${DEST}/flatcar_production_pxe.vmlinuz.sig"
 
 # PXE initrd and sig
 echo "flatcar_production_pxe_image.cpio.gz"

--- a/scripts/get-flatcar
+++ b/scripts/get-flatcar
@@ -39,37 +39,37 @@ fi
 echo "Downloading Flatcar Linux $CHANNEL $VERSION images and sigs to $DEST"
 
 echo "Flatcar Linux Image Signing Key"
-curl -# https://www.flatcar.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc -o "${DEST}/Flatcar_Image_Signing_Key.asc"
+curl -f# https://www.flatcar.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc -o "${DEST}/Flatcar_Image_Signing_Key.asc"
 $GPG --import <"$DEST/Flatcar_Image_Signing_Key.asc" || true
 
 # Version
 echo "version.txt"
-curl -# "${BASE_URL}/version.txt" -o "${DEST}/version.txt"
+curl -f# "${BASE_URL}/version.txt" -o "${DEST}/version.txt"
 
 # PXE kernel and sig
 echo "flatcar_production_pxe.vmlinuz..."
-curl -# "${BASE_URL}/flatcar_production_pxe.vmlinuz" -o "${DEST}/flatcar_production_pxe.vmlinuz"
+curl -f# "${BASE_URL}/flatcar_production_pxe.vmlinuz" -o "${DEST}/flatcar_production_pxe.vmlinuz"
 echo "flatcar_production_pxe.vmlinuz.sig"
-curl -# "${BASE_URL}/flatcar_production_pxe.vmlinuz.sig" -o "${DEST}/flatcar_production_pxe.vmlinuz.sig"
+curl -f# "${BASE_URL}/flatcar_production_pxe.vmlinuz.sig" -o "${DEST}/flatcar_production_pxe.vmlinuz.sig"
 
 # PXE initrd and sig
 echo "flatcar_production_pxe_image.cpio.gz"
-curl -# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz" -o "${DEST}/flatcar_production_pxe_image.cpio.gz"
+curl -f# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz" -o "${DEST}/flatcar_production_pxe_image.cpio.gz"
 echo "flatcar_production_pxe_image.cpio.gz.sig"
-curl -# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz.sig" -o "${DEST}/flatcar_production_pxe_image.cpio.gz.sig"
+curl -f# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz.sig" -o "${DEST}/flatcar_production_pxe_image.cpio.gz.sig"
 
 # Install image
 echo "flatcar_production_image.bin.bz2"
-curl -# "${BASE_URL}/flatcar_production_image.bin.bz2" -o "${DEST}/flatcar_production_image.bin.bz2"
+curl -f# "${BASE_URL}/flatcar_production_image.bin.bz2" -o "${DEST}/flatcar_production_image.bin.bz2"
 echo "flatcar_production_image.bin.bz2.sig"
-curl -# "${BASE_URL}/flatcar_production_image.bin.bz2.sig" -o "${DEST}/flatcar_production_image.bin.bz2.sig"
+curl -f# "${BASE_URL}/flatcar_production_image.bin.bz2.sig" -o "${DEST}/flatcar_production_image.bin.bz2.sig"
 
 # Install oem image
 if [[ -n "${IMAGE_NAME-}" ]]; then
   echo "${IMAGE_NAME}"
-  curl -# "${BASE_URL}/${IMAGE_NAME}" -o "${DEST}/${IMAGE_NAME}"
+  curl -f# "${BASE_URL}/${IMAGE_NAME}" -o "${DEST}/${IMAGE_NAME}"
   echo "${IMAGE_NAME}.sig"
-  curl -# "${BASE_URL}/${IMAGE_NAME}.sig" -o "${DEST}/${IMAGE_NAME}.sig"
+  curl -f# "${BASE_URL}/${IMAGE_NAME}.sig" -o "${DEST}/${IMAGE_NAME}.sig"
 fi
 
 # verify signatures


### PR DESCRIPTION
I was using the get-flatcar script and I noticed a failure as a result of some changes in the layout of the assets. I updated the scripts to fail if they encounter a server error.