### PR TITLE
Add -L flag to curl in scripts/get-flatcar to follow redirects.

### DIFF
--- a/scripts/get-flatcar
+++ b/scripts/get-flatcar
@@ -39,37 +39,37 @@ fi
 echo "Downloading Flatcar Linux $CHANNEL $VERSION images and sigs to $DEST"
 
 echo "Flatcar Linux Image Signing Key"
-curl -f# https://www.flatcar.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc -o "${DEST}/Flatcar_Image_Signing_Key.asc"
+curl -L -f# https://www.flatcar.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc -o "${DEST}/Flatcar_Image_Signing_Key.asc"
 $GPG --import <"$DEST/Flatcar_Image_Signing_Key.asc" || true
 
 # Version
 echo "version.txt"
-curl -f# "${BASE_URL}/version.txt" -o "${DEST}/version.txt"
+curl -L -f# "${BASE_URL}/version.txt" -o "${DEST}/version.txt"
 
 # PXE kernel and sig
 echo "flatcar_production_pxe.vmlinuz..."
-curl -f# "${BASE_URL}/flatcar_production_pxe.vmlinuz" -o "${DEST}/flatcar_production_pxe.vmlinuz"
+curl -L -f# "${BASE_URL}/flatcar_production_pxe.vmlinuz" -o "${DEST}/flatcar_production_pxe.vmlinuz"
 echo "flatcar_production_pxe.vmlinuz.sig"
-curl -f# "${BASE_URL}/flatcar_production_image.vmlinuz.sig" -o "${DEST}/flatcar_production_pxe.vmlinuz.sig"
+curl -L -f# "${BASE_URL}/flatcar_production_image.vmlinuz.sig" -o "${DEST}/flatcar_production_pxe.vmlinuz.sig"
 
 # PXE initrd and sig
 echo "flatcar_production_pxe_image.cpio.gz"
-curl -f# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz" -o "${DEST}/flatcar_production_pxe_image.cpio.gz"
+curl -L -f# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz" -o "${DEST}/flatcar_production_pxe_image.cpio.gz"
 echo "flatcar_production_pxe_image.cpio.gz.sig"
-curl -f# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz.sig" -o "${DEST}/flatcar_production_pxe_image.cpio.gz.sig"
+curl -L -f# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz.sig" -o "${DEST}/flatcar_production_pxe_image.cpio.gz.sig"
 
 # Install image
 echo "flatcar_production_image.bin.bz2"
-curl -f# "${BASE_URL}/flatcar_production_image.bin.bz2" -o "${DEST}/flatcar_production_image.bin.bz2"
+curl -L -f# "${BASE_URL}/flatcar_production_image.bin.bz2" -o "${DEST}/flatcar_production_image.bin.bz2"
 echo "flatcar_production_image.bin.bz2.sig"
-curl -f# "${BASE_URL}/flatcar_production_image.bin.bz2.sig" -o "${DEST}/flatcar_production_image.bin.bz2.sig"
+curl -L -f# "${BASE_URL}/flatcar_production_image.bin.bz2.sig" -o "${DEST}/flatcar_production_image.bin.bz2.sig"
 
 # Install oem image
 if [[ -n "${IMAGE_NAME-}" ]]; then
   echo "${IMAGE_NAME}"
-  curl -f# "${BASE_URL}/${IMAGE_NAME}" -o "${DEST}/${IMAGE_NAME}"
+  curl -L -f# "${BASE_URL}/${IMAGE_NAME}" -o "${DEST}/${IMAGE_NAME}"
   echo "${IMAGE_NAME}.sig"
-  curl -f# "${BASE_URL}/${IMAGE_NAME}.sig" -o "${DEST}/${IMAGE_NAME}.sig"
+  curl -L -f# "${BASE_URL}/${IMAGE_NAME}.sig" -o "${DEST}/${IMAGE_NAME}.sig"
 fi
 
 # verify signatures


### PR DESCRIPTION

Flatcar downloads from '[channel].flatcar-linux.net' now redirect (302) to 'flatcar.cdn.cncf.io/[channel]', so to still point the base url to flatcar's own domain, adding the '-L' ( '--location' ) will allow the script correctly get the needed files.

---

> _$ curl -sI https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt
HTTP/2 302
alt-svc: h3=":443"; ma=2592000
cache-control: max-age=300
location: https://flatcar.cdn.cncf.io/stable/amd64-usr/4459.2.3/version.txt
server: Caddy
date: Tue, 03 Mar 2026 20:40:04 GMT_