### PR TITLE
Add optional ARCH param to get-flatcar and get-fedora-coreos scripts

### DIFF
--- a/scripts/get-fedora-coreos
+++ b/scripts/get-fedora-coreos
@@ -7,11 +7,12 @@ set -eou pipefail
 STREAM=${1:-"stable"}
 VERSION=${2:-"36.20220906.3.2"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
+ARCH=${4:-"x64_64"}
 DEST=$DEST_DIR/fedora-coreos
-BASE_URL=https://builds.coreos.fedoraproject.org/prod/streams/$STREAM/builds/$VERSION/x86_64
+BASE_URL=https://builds.coreos.fedoraproject.org/prod/streams/$STREAM/builds/$VERSION/$ARCH
 
 # check stream/version exist based on the header response
-if ! curl -s -I $BASE_URL/fedora-coreos-$VERSION-metal.x86_64.raw.xz | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]' ; then
+if ! curl -s -I $BASE_URL/fedora-coreos-$VERSION-metal.${ARCH}.raw.xz | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]' ; then
   echo "Stream or Version not found"
   exit 1
 fi
@@ -21,16 +22,17 @@ if [ ! -d "$DEST" ]; then
   mkdir -p $DEST
 fi
 
-echo "Downloading Fedora CoreOS $STREAM $VERSION images to $DEST"
+echo "Downloading Fedora CoreOS $STREAM $VERSION $ARCH images to $DEST"
 
 # PXE kernel
-echo "fedora-coreos-$VERSION-live-kernel-x86_64"
-curl -f# $BASE_URL/fedora-coreos-$VERSION-live-kernel-x86_64 -o $DEST/fedora-coreos-$VERSION-live-kernel-x86_64
+# https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-live-kernel.aarch64
+echo "fedora-coreos-$VERSION-live-kernel.${ARCH}"
+curl -f# -L $BASE_URL/fedora-coreos-$VERSION-live-kernel.${ARCH} -o $DEST/fedora-coreos-$VERSION-live-kernel-${ARCH}
 
 # PXE initrd
-echo "fedora-coreos-$VERSION-live-initramfs.x86_64.img"
-curl -f# $BASE_URL/fedora-coreos-$VERSION-live-initramfs.x86_64.img -o $DEST/fedora-coreos-$VERSION-live-initramfs.x86_64.img
+echo "fedora-coreos-$VERSION-live-initramfs.${ARCH}.img"
+curl -f# -L $BASE_URL/fedora-coreos-$VERSION-live-initramfs.${ARCH}.img -o $DEST/fedora-coreos-$VERSION-live-initramfs.${ARCH}.img
 
 # rootfs
-echo "fedora-coreos-$VERSION-live-rootfs.x86_64.img"
-curl -f# $BASE_URL/fedora-coreos-$VERSION-live-rootfs.x86_64.img -o $DEST/fedora-coreos-$VERSION-live-rootfs.x86_64.img
+echo "fedora-coreos-$VERSION-live-rootfs.${ARCH}.img"
+curl -f# -L $BASE_URL/fedora-coreos-$VERSION-live-rootfs.${ARCH}.img -o $DEST/fedora-coreos-$VERSION-live-rootfs.${ARCH}.img

--- a/scripts/get-flatcar
+++ b/scripts/get-flatcar
@@ -39,37 +39,37 @@ fi
 echo "Downloading Flatcar Linux $CHANNEL $VERSION images and sigs to $DEST"
 
 echo "Flatcar Linux Image Signing Key"
-curl -f# https://www.flatcar.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc -o "${DEST}/Flatcar_Image_Signing_Key.asc"
+curl -L -f# https://www.flatcar.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc -o "${DEST}/Flatcar_Image_Signing_Key.asc"
 $GPG --import <"$DEST/Flatcar_Image_Signing_Key.asc" || true
 
 # Version
 echo "version.txt"
-curl -f# "${BASE_URL}/version.txt" -o "${DEST}/version.txt"
+curl -L -f# "${BASE_URL}/version.txt" -o "${DEST}/version.txt"
 
 # PXE kernel and sig
 echo "flatcar_production_pxe.vmlinuz..."
-curl -f# "${BASE_URL}/flatcar_production_pxe.vmlinuz" -o "${DEST}/flatcar_production_pxe.vmlinuz"
+curl -L -f# "${BASE_URL}/flatcar_production_pxe.vmlinuz" -o "${DEST}/flatcar_production_pxe.vmlinuz"
 echo "flatcar_production_pxe.vmlinuz.sig"
-curl -f# "${BASE_URL}/flatcar_production_image.vmlinuz.sig" -o "${DEST}/flatcar_production_pxe.vmlinuz.sig"
+curl -L -f# "${BASE_URL}/flatcar_production_image.vmlinuz.sig" -o "${DEST}/flatcar_production_pxe.vmlinuz.sig"
 
 # PXE initrd and sig
 echo "flatcar_production_pxe_image.cpio.gz"
-curl -f# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz" -o "${DEST}/flatcar_production_pxe_image.cpio.gz"
+curl -L -f# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz" -o "${DEST}/flatcar_production_pxe_image.cpio.gz"
 echo "flatcar_production_pxe_image.cpio.gz.sig"
-curl -f# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz.sig" -o "${DEST}/flatcar_production_pxe_image.cpio.gz.sig"
+curl -L -f# "${BASE_URL}/flatcar_production_pxe_image.cpio.gz.sig" -o "${DEST}/flatcar_production_pxe_image.cpio.gz.sig"
 
 # Install image
 echo "flatcar_production_image.bin.bz2"
-curl -f# "${BASE_URL}/flatcar_production_image.bin.bz2" -o "${DEST}/flatcar_production_image.bin.bz2"
+curl -L -f# "${BASE_URL}/flatcar_production_image.bin.bz2" -o "${DEST}/flatcar_production_image.bin.bz2"
 echo "flatcar_production_image.bin.bz2.sig"
-curl -f# "${BASE_URL}/flatcar_production_image.bin.bz2.sig" -o "${DEST}/flatcar_production_image.bin.bz2.sig"
+curl -L -f# "${BASE_URL}/flatcar_production_image.bin.bz2.sig" -o "${DEST}/flatcar_production_image.bin.bz2.sig"
 
 # Install oem image
 if [[ -n "${IMAGE_NAME-}" ]]; then
   echo "${IMAGE_NAME}"
-  curl -f# "${BASE_URL}/${IMAGE_NAME}" -o "${DEST}/${IMAGE_NAME}"
+  curl -L -f# "${BASE_URL}/${IMAGE_NAME}" -o "${DEST}/${IMAGE_NAME}"
   echo "${IMAGE_NAME}.sig"
-  curl -f# "${BASE_URL}/${IMAGE_NAME}.sig" -o "${DEST}/${IMAGE_NAME}.sig"
+  curl -L -f# "${BASE_URL}/${IMAGE_NAME}.sig" -o "${DEST}/${IMAGE_NAME}.sig"
 fi
 
 # verify signatures

--- a/scripts/get-flatcar
+++ b/scripts/get-flatcar
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # USAGE: ./scripts/get-flatcar
-# USAGE: ./scripts/get-flatcar channel version dest
+# USAGE: ./scripts/get-flatcar channel version dest arch
 #
 # ENV VARS:
 # - OEM_ID - specify OEM image id to download, alongside the default one
@@ -11,9 +11,11 @@ GPG=${GPG:-/usr/bin/gpg}
 CHANNEL=${1:-"stable"}
 VERSION=${2:-"current"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
+ARCH=${4:-"amd64"}
 OEM_ID=${OEM_ID:-""}
 DEST=$DEST_DIR/flatcar/$VERSION
-BASE_URL=https://$CHANNEL.release.flatcar-linux.net/amd64-usr/$VERSION
+BASE_URL=https://$CHANNEL.release.flatcar-linux.net/${ARCH}-usr/$VERSION
+echo "Base URL: ${BASE_URL}"
 
 # check channel/version exist based on the header response
 if ! curl -s -I "${BASE_URL}/flatcar_production_pxe.vmlinuz" | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]'; then


### PR DESCRIPTION
Based on gits (https://github.com/poseidon/matchbox/pull/1551#issuecomment-4431341337) from @bjwschaap, 
this adds a optional "ARCH" parameter to get-flatcar and get-fedora-coreos scripts.