### PR TITLE
Change image builds to podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ REPO=github.com/poseidon/matchbox
 LOCAL_REPO=poseidon/matchbox
 IMAGE_REPO=quay.io/poseidon/matchbox
 
+PLATFORM_amd64=linux/amd64
+PLATFORM_arm64=linux/arm64/v8
+
 .PHONY: all
 all: build test vet fmt
 
@@ -37,25 +40,26 @@ image: \
 	image-arm64
 
 image-%:
-	buildah bud -f Dockerfile \
+	podman build -f Dockerfile \
 	-t $(LOCAL_REPO):$(VERSION)-$* \
-	--arch $* --override-arch $* \
-	--format=docker .
+	--platform $(PLATFORM_$*) .
 
+.PHONY: push
 push: \
-	push-amd64
+	push-amd64 \
 	push-arm64
 
 push-%:
-	buildah tag $(LOCAL_REPO):$(VERSION)-$* $(IMAGE_REPO):$(VERSION)-$*
-	buildah push --format v2s2 $(IMAGE_REPO):$(VERSION)-$*
+	podman tag $(LOCAL_REPO):$(VERSION)-$* $(IMAGE_REPO):$(VERSION)-$*
+	podman push --format v2s2 $(IMAGE_REPO):$(VERSION)-$*
 
+.PHONY: manifest
 manifest:
-	buildah manifest create $(IMAGE_REPO):$(VERSION)
-	buildah manifest add $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-amd64
-	buildah manifest add --variant v8 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-arm64
-	buildah manifest inspect $(IMAGE_REPO):$(VERSION)
-	buildah manifest push -f v2s2 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)
+	podman manifest create $(IMAGE_REPO):$(VERSION)
+	podman manifest add $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-amd64
+	podman manifest add --variant v8 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)-arm64
+	podman manifest inspect $(IMAGE_REPO):$(VERSION)
+	podman manifest push -f v2s2 $(IMAGE_REPO):$(VERSION) docker://$(IMAGE_REPO):$(VERSION)
 
 protoc/%:
 	podman run --security-opt label=disable \

--- a/docs/dev/develop.md
+++ b/docs/dev/develop.md
@@ -18,18 +18,19 @@ $ make test
 
 ## Container image
 
-Build a container image `coreos/matchbox:latest`.
+Build a container image for your host architecture.
 
 ```sh
-$ make docker-image
+$ make image-$(go env GOARCH)
 ```
 
 ## Version
 
 ```sh
 $ ./bin/matchbox -version
-$ sudo docker run coreos/matchbox:latest -version
+$ podman run --rm poseidon/matchbox:$(git describe --tags --match=v* --always --dirty)-$(go env GOARCH) -version
 ```
+
 ## Run
 
 Run the binary.
@@ -38,10 +39,10 @@ Run the binary.
 $ ./bin/matchbox -address=0.0.0.0:8080 -log-level=debug -data-path examples -assets-path examples/assets
 ```
 
-Run the Docker image on `docker0`.
+Run the container image.
 
 ```sh
-$ sudo docker run -p 8080:8080 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z coreos/matchbox:latest -address=0.0.0.0:8080 -log-level=debug
+$ podman run -p 8080:8080 --rm -v $PWD/examples:/var/lib/matchbox:Z -v $PWD/examples/groups/etcd:/var/lib/matchbox/groups:Z poseidon/matchbox:$(git describe --tags --match=v* --always --dirty)-$(go env GOARCH) -address=0.0.0.0:8080 -log-level=debug
 ```
 
 ## bootcmd

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -23,10 +23,10 @@ $ git push origin main
 
 ## Images
 
-Travis CI will build the Docker image and push it to Quay.io when the tag is pushed to master. Verify the new image and version.
+GitHub Actions will build the container image and push it to Quay.io when the tag is pushed to master. Verify the new image and version.
 
 ```sh
-$ sudo docker run quay.io/poseidon/matchbox:$VERSION -version
+$ podman run --rm quay.io/poseidon/matchbox:$VERSION -version
 ```
 
 ## Github release


### PR DESCRIPTION
* Use podman for image build push and manifest targets
* Add platform mappings for amd64 and arm64 image builds
* Update development and release docs for Podman and GitHub Actions